### PR TITLE
Add advanced filtering and search to bookings and reservations

### DIFF
--- a/lib/src/features/home/bookings/bookings_provider.dart
+++ b/lib/src/features/home/bookings/bookings_provider.dart
@@ -1,8 +1,38 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/api/api_service.dart';
 
-final bookingsProvider = FutureProvider.autoDispose<List<Map<String, dynamic>>>((ref) async {
-  final dio = ref.read(dioProvider);
-  final response = await dio.get('/bookings');
+// Filter state provider - default to 'upcoming' instead of 'recent'
+final bookingFilterProvider = StateProvider<String>((ref) => 'upcoming');
+final bookingStatusFilterProvider = StateProvider<String?>((ref) => null);
+final bookingSearchProvider = StateProvider<String>((ref) => '');
+
+// Bookings provider with filtering
+final bookingsProvider = FutureProvider<List<Map<String, dynamic>>>((ref) async {
+  final dio = ref.watch(dioProvider);
+  final filter = ref.watch(bookingFilterProvider);
+  final statusFilter = ref.watch(bookingStatusFilterProvider);
+  final search = ref.watch(bookingSearchProvider);
+
+  // Build query parameters
+  final queryParams = <String, dynamic>{
+    'filter': filter,
+  };
+
+  if (statusFilter != null && statusFilter.isNotEmpty) {
+    queryParams['status'] = statusFilter;
+  }
+
+  if (search.isNotEmpty) {
+    queryParams['search'] = search;
+  }
+
+  print('📊 Fetching bookings with params: $queryParams');
+
+  final response = await dio.get('/bookings', queryParameters: queryParams);
+
+  print('✅ Received ${(response.data as List).length} bookings');
+
   return List<Map<String, dynamic>>.from(response.data);
 });
+
+// Note: bookingStatsProvider removed as statistics are no longer needed

--- a/lib/src/features/home/reservations/reservations_provider.dart
+++ b/lib/src/features/home/reservations/reservations_provider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:Zonova_Mist/src/core/api/api_service.dart';
+
+// Filter state provider for reservations - default to 'upcoming'
+final reservationFilterProvider = StateProvider<String>((ref) => 'upcoming');
+final reservationStatusFilterProvider = StateProvider<String?>((ref) => null);
+final reservationSearchProvider = StateProvider<String>((ref) => '');
+
+// Reservations provider with filtering
+final reservationsProvider = FutureProvider<List<Map<String, dynamic>>>((ref) async {
+  final dio = ref.watch(dioProvider);
+  final filter = ref.watch(reservationFilterProvider);
+  final statusFilter = ref.watch(reservationStatusFilterProvider);
+  final search = ref.watch(reservationSearchProvider);
+
+  // Build query parameters
+  final queryParams = <String, dynamic>{
+    'filter': filter,
+  };
+
+  if (statusFilter != null && statusFilter.isNotEmpty) {
+    queryParams['status'] = statusFilter;
+  }
+
+  if (search.isNotEmpty) {
+    queryParams['search'] = search;
+  }
+
+  print('📊 Fetching reservations with params: $queryParams');
+
+  final response = await dio.get('/bookings', queryParameters: queryParams);
+
+  print('✅ Received ${(response.data as List).length} reservations');
+
+  return List<Map<String, dynamic>>.from(response.data);
+});

--- a/lib/src/features/home/reservations/reservations_screen.dart
+++ b/lib/src/features/home/reservations/reservations_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:intl/intl.dart';
-import '../../../core/auth/reservations_provider.dart';
+import 'reservations_provider.dart';
 import 'package:Zonova_Mist/src/core/api/api_service.dart';
 
 class ReservationsScreen extends ConsumerWidget {
@@ -34,125 +34,467 @@ class ReservationsScreen extends ConsumerWidget {
     }
   }
 
+  void _showFilterSheet(BuildContext context, WidgetRef ref) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) => DraggableScrollableSheet(
+        initialChildSize: 0.5,
+        minChildSize: 0.3,
+        maxChildSize: 0.8,
+        expand: false,
+        builder: (context, scrollController) => ReservationFilterBottomSheet(
+          scrollController: scrollController,
+        ),
+      ),
+    );
+  }
+
+  void _showSearchDialog(BuildContext context, WidgetRef ref) {
+    final searchController = TextEditingController(
+      text: ref.read(reservationSearchProvider),
+    );
+
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Search Reservations'),
+        content: TextField(
+          controller: searchController,
+          autofocus: true,
+          decoration: const InputDecoration(
+            labelText: 'Search by name, room, or phone',
+            prefixIcon: Icon(Icons.search),
+            border: OutlineInputBorder(),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              ref.read(reservationSearchProvider.notifier).state = '';
+              Navigator.pop(context);
+            },
+            child: const Text('Clear'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              ref.read(reservationSearchProvider.notifier).state = searchController.text;
+              Navigator.pop(context);
+            },
+            child: const Text('Search'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final reservationsAsync = ref.watch(reservationsProvider);
+    final currentFilter = ref.watch(reservationFilterProvider);
+    final statusFilter = ref.watch(reservationStatusFilterProvider);
+    final searchQuery = ref.watch(reservationSearchProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text("Reservations")),
-      body: reservationsAsync.when(
-        data: (reservations) {
-          if (reservations.isEmpty) {
-            return const Center(child: Text("No reservations found."));
-          }
-          return ListView.builder(
-            padding: const EdgeInsets.all(12),
-            itemCount: reservations.length,
-            itemBuilder: (context, index) {
-              final booking = reservations[index];
-              return Slidable(
-                key: ValueKey(booking['_id']),
-                endActionPane: ActionPane(
-                  motion: const DrawerMotion(),
-                  extentRatio: 0.6,
+      appBar: AppBar(
+        title: const Text("Reservations"),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () => _showSearchDialog(context, ref),
+          ),
+          IconButton(
+            icon: Badge(
+              isLabelVisible: currentFilter != 'upcoming' || statusFilter != null || searchQuery.isNotEmpty,
+              label: const Text('•'),
+              child: const Icon(Icons.filter_list),
+            ),
+            onPressed: () => _showFilterSheet(context, ref),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          // Active Filter Chips
+          if (currentFilter != 'upcoming' || statusFilter != null || searchQuery.isNotEmpty)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              color: Colors.blue.shade50,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
                   children: [
-                    SlidableAction(
-                      onPressed: (_) => _updateStatus(context, ref, booking, "paid"),
-                      backgroundColor: Colors.green,
-                      foregroundColor: Colors.white,
-                      icon: Icons.check,
-                      label: 'Mark Paid',
-                    ),
-                    SlidableAction(
-                      onPressed: (_) => _updateStatus(context, ref, booking, "cancelled"),
-                      backgroundColor: Colors.red,
-                      foregroundColor: Colors.white,
-                      icon: Icons.block,
-                      label: 'Deny Entry',
+                    if (currentFilter != 'upcoming')
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: Chip(
+                          label: Text(_getFilterLabel(currentFilter)),
+                          deleteIcon: const Icon(Icons.close, size: 18),
+                          onDeleted: () {
+                            ref.read(reservationFilterProvider.notifier).state = 'upcoming';
+                          },
+                        ),
+                      ),
+                    if (statusFilter != null)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: Chip(
+                          label: Text('Status: ${statusFilter.toUpperCase()}'),
+                          deleteIcon: const Icon(Icons.close, size: 18),
+                          onDeleted: () {
+                            ref.read(reservationStatusFilterProvider.notifier).state = null;
+                          },
+                        ),
+                      ),
+                    if (searchQuery.isNotEmpty)
+                      Chip(
+                        label: Text('Search: $searchQuery'),
+                        deleteIcon: const Icon(Icons.close, size: 18),
+                        onDeleted: () {
+                          ref.read(reservationSearchProvider.notifier).state = '';
+                        },
+                      ),
+                    TextButton.icon(
+                      onPressed: () {
+                        ref.read(reservationFilterProvider.notifier).state = 'upcoming';
+                        ref.read(reservationStatusFilterProvider.notifier).state = null;
+                        ref.read(reservationSearchProvider.notifier).state = '';
+                      },
+                      icon: const Icon(Icons.clear_all, size: 18),
+                      label: const Text('Clear All'),
                     ),
                   ],
                 ),
-                child: Card(
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  elevation: 4,
-                  margin: const EdgeInsets.symmetric(vertical: 8),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
+              ),
+            ),
+
+          // Reservations List
+          Expanded(
+            child: reservationsAsync.when(
+              data: (reservations) {
+                if (reservations.isEmpty) {
+                  return Center(
                     child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Row(
-                          children: [
-                            Icon(Icons.person, color: Colors.blue.shade700),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                booking['guest_name'] ?? 'Unknown Guest',
-                                style: const TextStyle(
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ],
+                        Icon(Icons.inbox_outlined, size: 64, color: Colors.grey.shade400),
+                        const SizedBox(height: 16),
+                        Text(
+                          'No reservations found',
+                          style: TextStyle(fontSize: 18, color: Colors.grey.shade600),
                         ),
                         const SizedBox(height: 8),
-                        Row(
-                          children: [
-                            const Icon(Icons.meeting_room, size: 18, color: Colors.grey),
-                            const SizedBox(width: 6),
-                            Text("Room(s): ${booking['booked_room_no'] ?? 'N/A'}"),
-                          ],
-                        ),
-                        const SizedBox(height: 6),
-                        Row(
-                          children: [
-                            const Icon(Icons.calendar_today, size: 18, color: Colors.grey),
-                            const SizedBox(width: 6),
-                            Text(
-                              'Check-in: ${booking['checkin_date'] != null ? DateFormat('MMM dd, yyyy').format(DateTime.parse(booking['checkin_date'])) : 'N/A'}',
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 6),
-                        Row(
-                          children: [
-                            const Icon(Icons.phone, size: 18, color: Colors.grey),
-                            const SizedBox(width: 6),
-                            Text('Phone: ${booking['phone_no'] ?? 'N/A'}'),
-                          ],
-                        ),
-                        const SizedBox(height: 6),
-                        Row(
-                          children: [
-                            const Icon(Icons.check_circle, size: 18, color: Colors.grey),
-                            const SizedBox(width: 6),
-                            Text(
-                              'Status: ${booking['status'] ?? 'N/A'}',
-                              style: TextStyle(
-                                color: (booking['status'] == 'paid')
-                                    ? Colors.green
-                                    : (booking['status'] == 'pending')
-                                    ? Colors.orange
-                                    : Colors.red,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                          ],
+                        Text(
+                          'Try adjusting your filters',
+                          style: TextStyle(fontSize: 14, color: Colors.grey.shade500),
                         ),
                       ],
                     ),
-                  ),
+                  );
+                }
+                return ListView.builder(
+                  padding: const EdgeInsets.all(12),
+                  itemCount: reservations.length,
+                  itemBuilder: (context, index) {
+                    final booking = reservations[index];
+                    return Slidable(
+                      key: ValueKey(booking['_id']),
+                      endActionPane: ActionPane(
+                        motion: const DrawerMotion(),
+                        extentRatio: 0.6,
+                        children: [
+                          SlidableAction(
+                            onPressed: (_) => _updateStatus(context, ref, booking, "paid"),
+                            backgroundColor: Colors.green,
+                            foregroundColor: Colors.white,
+                            icon: Icons.check,
+                            label: 'Mark Paid',
+                          ),
+                          SlidableAction(
+                            onPressed: (_) => _updateStatus(context, ref, booking, "cancelled"),
+                            backgroundColor: Colors.red,
+                            foregroundColor: Colors.white,
+                            icon: Icons.block,
+                            label: 'Deny Entry',
+                          ),
+                        ],
+                      ),
+                      child: Card(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        elevation: 4,
+                        margin: const EdgeInsets.symmetric(vertical: 8),
+                        child: Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                children: [
+                                  Icon(Icons.person, color: Colors.blue.shade700),
+                                  const SizedBox(width: 8),
+                                  Expanded(
+                                    child: Text(
+                                      booking['guest_name'] ?? 'Unknown Guest',
+                                      style: const TextStyle(
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                  _buildStatusChip(booking['status']),
+                                ],
+                              ),
+                              const SizedBox(height: 8),
+                              Row(
+                                children: [
+                                  const Icon(Icons.meeting_room, size: 18, color: Colors.grey),
+                                  const SizedBox(width: 6),
+                                  Text("Room(s): ${booking['booked_room_no'] ?? 'N/A'}"),
+                                ],
+                              ),
+                              const SizedBox(height: 6),
+                              Row(
+                                children: [
+                                  const Icon(Icons.calendar_today, size: 18, color: Colors.grey),
+                                  const SizedBox(width: 6),
+                                  Text(
+                                    'Check-in: ${booking['checkin_date'] != null ? DateFormat('MMM dd, yyyy').format(DateTime.parse(booking['checkin_date'])) : 'N/A'}',
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 6),
+                              Row(
+                                children: [
+                                  const Icon(Icons.phone, size: 18, color: Colors.grey),
+                                  const SizedBox(width: 6),
+                                  Text('Phone: ${booking['phone_no'] ?? 'N/A'}'),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                );
+              },
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (err, stack) => Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.error_outline, size: 48, color: Colors.red),
+                    const SizedBox(height: 16),
+                    Text('Error: $err'),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: () => ref.refresh(reservationsProvider),
+                      child: const Text('Retry'),
+                    ),
+                  ],
                 ),
-              );
-            },
-          );
-        },
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (err, stack) => Center(child: Text('Error: $err')),
+              ),
+            ),
+          ),
+        ],
       ),
+    );
+  }
+
+  Widget _buildStatusChip(String? status) {
+    Color color;
+    IconData icon;
+
+    switch (status?.toLowerCase()) {
+      case 'paid':
+        color = Colors.green;
+        icon = Icons.check_circle;
+        break;
+      case 'cancelled':
+        color = Colors.red;
+        icon = Icons.cancel;
+        break;
+      case 'pending':
+      default:
+        color = Colors.orange;
+        icon = Icons.pending;
+        break;
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: color),
+          const SizedBox(width: 4),
+          Text(
+            (status ?? 'pending').toUpperCase(),
+            style: TextStyle(
+              color: color,
+              fontSize: 11,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _getFilterLabel(String filter) {
+    switch (filter) {
+      case 'upcoming':
+        return 'Upcoming & Today';
+      case 'recent':
+        return 'Last 7 Days';
+      case 'today':
+        return 'Today Only';
+      case 'week':
+        return 'This Week';
+      case 'month':
+        return 'This Month';
+      case 'past':
+        return 'Past';
+      case 'all':
+        return 'All Bookings';
+      default:
+        return filter;
+    }
+  }
+}
+
+class ReservationFilterBottomSheet extends ConsumerWidget {
+  final ScrollController scrollController;
+
+  const ReservationFilterBottomSheet({super.key, required this.scrollController});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentFilter = ref.watch(reservationFilterProvider);
+    final statusFilter = ref.watch(reservationStatusFilterProvider);
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      child: ListView(
+        controller: scrollController,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                'Filter Reservations',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => Navigator.pop(context),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+
+          // Date Range Filters
+          const Text(
+            'Date Range',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildFilterChip(context, ref, 'upcoming', 'Upcoming & Today', Icons.arrow_forward, currentFilter),
+              _buildFilterChip(context, ref, 'today', 'Today Only', Icons.today, currentFilter),
+              _buildFilterChip(context, ref, 'recent', 'Last 7 Days', Icons.calendar_today, currentFilter),
+              _buildFilterChip(context, ref, 'week', 'This Week', Icons.date_range, currentFilter),
+              _buildFilterChip(context, ref, 'month', 'This Month', Icons.calendar_month, currentFilter),
+              _buildFilterChip(context, ref, 'past', 'Past', Icons.history, currentFilter),
+              _buildFilterChip(context, ref, 'all', 'All Reservations', Icons.all_inclusive, currentFilter),
+            ],
+          ),
+
+          const SizedBox(height: 24),
+
+          // Status Filters
+          const Text(
+            'Payment Status',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildStatusFilterChip(context, ref, null, 'All Statuses', Icons.filter_list, statusFilter),
+              _buildStatusFilterChip(context, ref, 'pending', 'Pending', Icons.pending, statusFilter),
+              _buildStatusFilterChip(context, ref, 'paid', 'Paid', Icons.check_circle, statusFilter),
+              _buildStatusFilterChip(context, ref, 'cancelled', 'Cancelled', Icons.cancel, statusFilter),
+            ],
+          ),
+
+          const SizedBox(height: 32),
+
+          // Apply Button
+          SizedBox(
+            width: double.infinity,
+            height: 50,
+            child: ElevatedButton(
+              onPressed: () => Navigator.pop(context),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blue.shade700,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('Apply Filters', style: TextStyle(fontSize: 16)),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterChip(BuildContext context, WidgetRef ref, String value, String label, IconData icon, String currentFilter) {
+    final isSelected = currentFilter == value;
+    return FilterChip(
+      selected: isSelected,
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16),
+          const SizedBox(width: 4),
+          Text(label),
+        ],
+      ),
+      onSelected: (selected) {
+        ref.read(reservationFilterProvider.notifier).state = value;
+      },
+    );
+  }
+
+  Widget _buildStatusFilterChip(BuildContext context, WidgetRef ref, String? value, String label, IconData icon, String? currentStatus) {
+    final isSelected = currentStatus == value;
+    return FilterChip(
+      selected: isSelected,
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16),
+          const SizedBox(width: 4),
+          Text(label),
+        ],
+      ),
+      onSelected: (selected) {
+        ref.read(reservationStatusFilterProvider.notifier).state = value;
+      },
     );
   }
 }


### PR DESCRIPTION
Introduces filter and search state providers for both bookings and reservations, enabling filtering by date range, status, and search query. Updates the UI to include filter chips, filter bottom sheets, and search dialogs for both screens. Refactors providers to use query parameters for filtering, and improves empty/error state handling. Adds a new reservations_provider.dart for reservations logic.