### PR TITLE
Add status filter options for bookings and reservations

### DIFF
--- a/lib/src/features/home/bookings/bookings_provider.dart
+++ b/lib/src/features/home/bookings/bookings_provider.dart
@@ -18,9 +18,12 @@ final bookingsProvider = FutureProvider<List<Map<String, dynamic>>>((ref) async 
     'filter': filter,
   };
 
+  // When statusFilter is null or empty, backend will automatically exclude cancelled
+  // When statusFilter has a specific value, backend will show only that status
   if (statusFilter != null && statusFilter.isNotEmpty) {
     queryParams['status'] = statusFilter;
   }
+  // If statusFilter is null/empty, don't add status param - backend will exclude cancelled by default
 
   if (search.isNotEmpty) {
     queryParams['search'] = search;

--- a/lib/src/features/home/bookings/bookings_screen.dart
+++ b/lib/src/features/home/bookings/bookings_screen.dart
@@ -616,6 +616,7 @@ class FilterBottomSheet extends ConsumerWidget {
               _buildStatusFilterChip(context, ref, null, 'All Statuses', Icons.filter_list, statusFilter),
               _buildStatusFilterChip(context, ref, 'advance_paid', 'Advance Paid', Icons.payments, statusFilter),
               _buildStatusFilterChip(context, ref, 'paid', 'Paid', Icons.check_circle, statusFilter),
+              _buildStatusFilterChip(context, ref, 'pending', 'Pending', Icons.pending, statusFilter),
               _buildStatusFilterChip(context, ref, 'cancelled', 'Cancelled', Icons.cancel, statusFilter),
             ],
           ),

--- a/lib/src/features/home/reservations/reservations_provider.dart
+++ b/lib/src/features/home/reservations/reservations_provider.dart
@@ -18,9 +18,12 @@ final reservationsProvider = FutureProvider<List<Map<String, dynamic>>>((ref) as
     'filter': filter,
   };
 
+  // When statusFilter is null or empty, backend will automatically exclude cancelled
+  // When statusFilter has a specific value, backend will show only that status
   if (statusFilter != null && statusFilter.isNotEmpty) {
     queryParams['status'] = statusFilter;
   }
+  // If statusFilter is null/empty, don't add status param - backend will exclude cancelled by default
 
   if (search.isNotEmpty) {
     queryParams['search'] = search;

--- a/lib/src/features/home/reservations/reservations_screen.dart
+++ b/lib/src/features/home/reservations/reservations_screen.dart
@@ -521,6 +521,9 @@ class ReservationFilterBottomSheet extends ConsumerWidget {
             children: [
               _buildStatusFilterChip(context, ref, null, 'All Statuses', Icons.filter_list, statusFilter),
               _buildStatusFilterChip(context, ref, 'pending', 'Pending', Icons.pending, statusFilter),
+              _buildStatusFilterChip(context, ref, 'advance_paid', 'Advance Paid', Icons.payments, statusFilter),
+              _buildStatusFilterChip(context, ref, 'paid', 'Paid', Icons.check_circle, statusFilter),
+              _buildStatusFilterChip(context, ref, 'cancelled', 'Cancelled', Icons.cancel, statusFilter),
             ],
           ),
 


### PR DESCRIPTION
Added 'Pending', 'Advance Paid', 'Paid', and 'Cancelled' status filter chips to bookings and reservations filter sheets. Updated provider logic to clarify backend behavior when statusFilter is null or empty, ensuring cancelled items are excluded by default unless a specific status is selected.