### PR TITLE
Add role-based access control (RBAC) gating across app screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,7 +46,7 @@ class MyApp extends ConsumerWidget {
         // While checking for a stored token, show a splash screen
         loading: () => const SplashScreen(),
         // If authenticated, show the home screen
-        authenticated: (_) => const HomeScreen(),
+        authenticated: (_, __, ___) => const HomeScreen(),
         // If not, show the login screen
         unauthenticated: () => const LoginScreen(),
         // On error, also default to login screen

--- a/lib/src/core/auth/auth_constants.dart
+++ b/lib/src/core/auth/auth_constants.dart
@@ -1,0 +1,16 @@
+class AuthConstants {
+  static const String jwtKey = 'jwt_token';
+  static const String userFullNameKey = 'user_full_name';
+  static const String userRoleKey = 'user_role';
+  static const String userPermissionsKey = 'user_permissions';
+}
+
+class AppRoles {
+  static const String superAdmin = 'super_admin';
+  static const String guestHouseAdmin = 'guest_house_admin';
+  static const String receptionist = 'receptionist';
+  static const String housekeeping = 'housekeeping';
+  static const String maintenance = 'maintenance';
+  static const String finance = 'finance';
+  static const String guest = 'guest';
+}

--- a/lib/src/core/auth/auth_provider.dart
+++ b/lib/src/core/auth/auth_provider.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:Zonova_Mist/src/core/auth/auth_state.dart';
 import 'package:Zonova_Mist/src/core/api/api_service.dart';
+import 'package:Zonova_Mist/src/core/auth/auth_constants.dart';
+import 'package:Zonova_Mist/src/core/auth/auth_utils.dart';
 
 
 final tokenProvider = StateProvider<String?>((ref) => null);
@@ -18,45 +20,70 @@ class AuthNotifier extends StateNotifier<AuthState> {
   final _storage = const FlutterSecureStorage();
 
   Future<void> _checkToken() async {
-    final token = await _storage.read(key: 'jwt_token');
-    if (token != null) {
-      // 2. LOAD TOKEN INTO RAM ON APP START
-      _ref.read(tokenProvider.notifier).state = token;
-      
-      final userFullName = await _storage.read(key: 'user_full_name');
-      final role = await _storage.read(key: 'user_role') ?? 'Guest';
-      final permissionsRaw = await _storage.read(key: 'user_permissions');
-      final permissions = _decodePermissions(permissionsRaw);
-      state = Authenticated(
-        userName: userFullName ?? 'User',
-        role: role,
-        permissions: permissions,
-      );
-    } else {
-      state = const Unauthenticated();
+    try {
+      final token = await _storage.read(key: AuthConstants.jwtKey);
+      if (token != null) {
+        // Treat malformed/expired tokens as absent
+        if (isJwtExpired(token)) {
+          await _storage.delete(key: AuthConstants.jwtKey);
+          state = const Unauthenticated();
+          return;
+        }
+
+        // 2. LOAD TOKEN INTO RAM ON APP START
+        _ref.read(tokenProvider.notifier).state = token;
+
+        final userFullName = await _storage.read(key: AuthConstants.userFullNameKey);
+        final role = await _storage.read(key: AuthConstants.userRoleKey) ?? safeGetRoleFromPayload(token) ?? 'Guest';
+        final permissionsRaw = await _storage.read(key: AuthConstants.userPermissionsKey);
+        final permissions = _decodePermissions(permissionsRaw);
+        state = Authenticated(
+          userName: userFullName ?? 'User',
+          role: role,
+          permissions: permissions,
+        );
+      } else {
+        state = const Unauthenticated();
+      }
+    } catch (e, st) {
+      // Storage/read error -> mark as error but fall back to unauthenticated
+      state = AuthError('Failed to read authentication data', type: AuthErrorType.storage, cause: e);
+      Future.delayed(const Duration(seconds: 1), () => state = const Unauthenticated());
     }
   }
 
   Future<void> login(String email, String password) async {
     state = const AuthLoading();
     try {
-      print("before call");
       final response = await _ref.read(dioProvider).post(
         '/auth/login',
         data: {'email': email, 'password': password},
         options: Options(headers: {'Content-Type': 'application/json'}),
       );
-      print("after call");
-      final token = response.data['token'];
-      final userFullName = response.data['user']['fullName'];
-      final role = response.data['user']['role'] ?? response.data['role'] ?? 'Guest';
+
+      final token = response.data['token'] as String?;
+      final userFullName = response.data['user']?['fullName'] ?? response.data['userFullName'] ?? 'User';
+      final role = response.data['user']?['role'] ?? response.data['role'] ?? 'Guest';
       final permissions = _extractPermissions(response.data);
 
+      if (token == null) {
+        state = const AuthError('Authentication token missing from response', type: AuthErrorType.unknown);
+        Future.delayed(const Duration(seconds: 2), () => state = const Unauthenticated());
+        return;
+      }
+
+      // Check token expiry
+      if (isJwtExpired(token)) {
+        state = const AuthError('Received expired token', type: AuthErrorType.expiredToken);
+        Future.delayed(const Duration(seconds: 2), () => state = const Unauthenticated());
+        return;
+      }
+
       // Write to Disk (Slow, Persistent)
-      await _storage.write(key: 'jwt_token', value: token);
-      await _storage.write(key: 'user_full_name', value: userFullName);
-      await _storage.write(key: 'user_role', value: role.toString());
-      await _storage.write(key: 'user_permissions', value: jsonEncode(permissions));
+      await _storage.write(key: AuthConstants.jwtKey, value: token);
+      await _storage.write(key: AuthConstants.userFullNameKey, value: userFullName);
+      await _storage.write(key: AuthConstants.userRoleKey, value: role.toString());
+      await _storage.write(key: AuthConstants.userPermissionsKey, value: jsonEncode(permissions));
 
       // 3. UPDATE RAM IMMEDIATELY (Fast, for immediate API calls)
       _ref.read(tokenProvider.notifier).state = token;
@@ -67,15 +94,18 @@ class AuthNotifier extends StateNotifier<AuthState> {
         permissions: permissions,
       );
     } on DioException catch (e) {
-      print("exception $e");
-      final message = e.response?.data['message'] ?? 'An unknown error occurred';
-      state = AuthError(message);
+      final message = e.response?.data != null
+          ? (e.response!.data is Map ? (e.response!.data['message'] ?? 'An unknown error occurred') : e.response!.data.toString())
+          : e.message ?? 'Network error';
+      state = AuthError(message, type: AuthErrorType.network, cause: e);
+      Future.delayed(const Duration(seconds: 2), () => state = const Unauthenticated());
+    } catch (e) {
+      state = AuthError('An unexpected error occurred', type: AuthErrorType.unknown, cause: e);
       Future.delayed(const Duration(seconds: 2), () => state = const Unauthenticated());
     }
   }
 
   Future<String> register({required String fullName, required String email, required String password}) async {
-
     state = const AuthLoading();
     try {
       await _ref.read(dioProvider).post(
@@ -86,18 +116,26 @@ class AuthNotifier extends StateNotifier<AuthState> {
       return 'Success';
     } on DioException catch (e) {
       final message = e.response?.data['message'] ?? 'An unknown error occurred';
-      state = AuthError(message);
+      state = AuthError(message, type: AuthErrorType.network, cause: e);
       Future.delayed(const Duration(seconds: 2), () => state = const Unauthenticated());
       return message;
+    } catch (e) {
+      state = AuthError('An unexpected error occurred', type: AuthErrorType.unknown, cause: e);
+      Future.delayed(const Duration(seconds: 2), () => state = const Unauthenticated());
+      return 'An unexpected error occurred';
     }
   }
 
   Future<void> logout() async {
-    await _storage.deleteAll();
-    
+    try {
+      await _storage.deleteAll();
+    } catch (_) {
+      // ignore storage delete errors, still clear RAM
+    }
+
     // 4. CLEAR RAM ON LOGOUT
     _ref.read(tokenProvider.notifier).state = null;
-    
+
     state = const Unauthenticated();
   }
 
@@ -115,10 +153,12 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }
 
   List<String> _extractPermissions(Map<String, dynamic> data) {
-    final permissions = data['permissions'] ?? data['user']?['permissions'];
-    if (permissions is List) {
-      return permissions.map((permission) => permission.toString()).toList();
-    }
+    try {
+      final permissions = data['permissions'] ?? data['user']?['permissions'];
+      if (permissions is List) {
+        return permissions.map((permission) => permission.toString()).toList();
+      }
+    } catch (_) {}
     return <String>[];
   }
 }

--- a/lib/src/core/auth/auth_provider.dart
+++ b/lib/src/core/auth/auth_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -22,7 +24,14 @@ class AuthNotifier extends StateNotifier<AuthState> {
       _ref.read(tokenProvider.notifier).state = token;
       
       final userFullName = await _storage.read(key: 'user_full_name');
-      state = Authenticated(userFullName ?? 'User');
+      final role = await _storage.read(key: 'user_role') ?? 'Guest';
+      final permissionsRaw = await _storage.read(key: 'user_permissions');
+      final permissions = _decodePermissions(permissionsRaw);
+      state = Authenticated(
+        userName: userFullName ?? 'User',
+        role: role,
+        permissions: permissions,
+      );
     } else {
       state = const Unauthenticated();
     }
@@ -40,15 +49,23 @@ class AuthNotifier extends StateNotifier<AuthState> {
       print("after call");
       final token = response.data['token'];
       final userFullName = response.data['user']['fullName'];
+      final role = response.data['user']['role'] ?? response.data['role'] ?? 'Guest';
+      final permissions = _extractPermissions(response.data);
 
       // Write to Disk (Slow, Persistent)
       await _storage.write(key: 'jwt_token', value: token);
       await _storage.write(key: 'user_full_name', value: userFullName);
+      await _storage.write(key: 'user_role', value: role.toString());
+      await _storage.write(key: 'user_permissions', value: jsonEncode(permissions));
 
       // 3. UPDATE RAM IMMEDIATELY (Fast, for immediate API calls)
       _ref.read(tokenProvider.notifier).state = token;
 
-      state = Authenticated(userFullName);
+      state = Authenticated(
+        userName: userFullName,
+        role: role.toString(),
+        permissions: permissions,
+      );
     } on DioException catch (e) {
       print("exception $e");
       final message = e.response?.data['message'] ?? 'An unknown error occurred';
@@ -82,6 +99,27 @@ class AuthNotifier extends StateNotifier<AuthState> {
     _ref.read(tokenProvider.notifier).state = null;
     
     state = const Unauthenticated();
+  }
+
+  List<String> _decodePermissions(String? permissionsRaw) {
+    if (permissionsRaw == null || permissionsRaw.isEmpty) {
+      return <String>[];
+    }
+    try {
+      final decoded = jsonDecode(permissionsRaw);
+      if (decoded is List) {
+        return decoded.map((permission) => permission.toString()).toList();
+      }
+    } catch (_) {}
+    return <String>[];
+  }
+
+  List<String> _extractPermissions(Map<String, dynamic> data) {
+    final permissions = data['permissions'] ?? data['user']?['permissions'];
+    if (permissions is List) {
+      return permissions.map((permission) => permission.toString()).toList();
+    }
+    return <String>[];
   }
 }
 

--- a/lib/src/core/auth/auth_state.dart
+++ b/lib/src/core/auth/auth_state.dart
@@ -24,9 +24,14 @@ class Unauthenticated extends AuthState {
   const Unauthenticated();
 }
 
+enum AuthErrorType { network, expiredToken, invalidToken, storage, unknown }
+
 class AuthError extends AuthState {
   final String message;
-  const AuthError(this.message);
+  final AuthErrorType type;
+  final dynamic cause;
+
+  const AuthError(this.message, {this.type = AuthErrorType.unknown, this.cause});
 }
 
 // Using a Freezed-like pattern for convenience
@@ -51,5 +56,18 @@ extension AuthStateX on AuthState {
       return error((this as AuthError).message);
     }
     throw Exception('Unhandled AuthState: $this');
+  }
+}
+
+// Optional helpers for callers that want the typed error
+extension AuthStateErrorHelpers on AuthState {
+  AuthErrorType? get errorType {
+    if (this is AuthError) return (this as AuthError).type;
+    return null;
+  }
+
+  dynamic get errorCause {
+    if (this is AuthError) return (this as AuthError).cause;
+    return null;
   }
 }

--- a/lib/src/core/auth/auth_state.dart
+++ b/lib/src/core/auth/auth_state.dart
@@ -11,7 +11,13 @@ class AuthLoading extends AuthState {
 
 class Authenticated extends AuthState {
   final String userName;
-  const Authenticated(this.userName);
+  final String role;
+  final List<String> permissions;
+  const Authenticated({
+    required this.userName,
+    required this.role,
+    required this.permissions,
+  });
 }
 
 class Unauthenticated extends AuthState {
@@ -27,7 +33,7 @@ class AuthError extends AuthState {
 extension AuthStateX on AuthState {
   T when<T>({
     required T Function() loading,
-    required T Function(String userName) authenticated,
+    required T Function(String userName, String role, List<String> permissions) authenticated,
     required T Function() unauthenticated,
     required T Function(String message) error,
   }) {
@@ -35,7 +41,8 @@ extension AuthStateX on AuthState {
       return loading();
     }
     if (this is Authenticated) {
-      return authenticated((this as Authenticated).userName);
+      final auth = this as Authenticated;
+      return authenticated(auth.userName, auth.role, auth.permissions);
     }
     if (this is Unauthenticated) {
       return unauthenticated();

--- a/lib/src/core/auth/auth_utils.dart
+++ b/lib/src/core/auth/auth_utils.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+// Minimal, dependency-free JWT payload decoder to check exp safely.
+// Returns the payload map or null on malformed token.
+Map<String, dynamic>? decodeJwtPayload(String? token) {
+  if (token == null || token.isEmpty) return null;
+  try {
+    final parts = token.split('.');
+    if (parts.length != 3) return null;
+    final payload = parts[1];
+    // Base64 decode with proper padding
+    var normalized = base64Url.normalize(payload);
+    final decoded = utf8.decode(base64Url.decode(normalized));
+    final Map<String, dynamic> map = jsonDecode(decoded) as Map<String, dynamic>;
+    return map;
+  } catch (_) {
+    return null;
+  }
+}
+
+bool isJwtExpired(String? token) {
+  final payload = decodeJwtPayload(token);
+  if (payload == null) return true; // treat malformed as expired/invalid
+  try {
+    final exp = payload['exp'];
+    if (exp == null) return false; // no exp claim -> assume non-expiring
+    final expInt = (exp is int) ? exp : int.parse(exp.toString());
+    final expiry = DateTime.fromMillisecondsSinceEpoch(expInt * 1000);
+    return DateTime.now().isAfter(expiry);
+  } catch (_) {
+    return true;
+  }
+}
+
+String? safeGetRoleFromPayload(String? token) {
+  final payload = decodeJwtPayload(token);
+  if (payload == null) return null;
+  // common claim names: role, roles, r
+  final role = payload['role'] ?? payload['roles'] ?? payload['r'];
+  if (role == null) return null;
+  if (role is String) return role;
+  if (role is List && role.isNotEmpty) return role.first.toString();
+  return null;
+}

--- a/lib/src/core/auth/rbac.dart
+++ b/lib/src/core/auth/rbac.dart
@@ -1,3 +1,5 @@
+import 'package:Zonova_Mist/src/core/auth/auth_constants.dart';
+
 enum AppPermission {
   dashboard,
   bookings,
@@ -40,9 +42,22 @@ const Map<AppPermission, String> permissionLabels = {
   AppPermission.assets: 'Assets',
 };
 
+/// Admin roles that bypass all permission checks.
+/// Backend guarantees these roles ALWAYS have access.
+/// Roles from backend are lowercase: 'admin', 'super_admin', 'guest_house_admin', etc.
+const Set<String> _adminRoles = {
+  'admin',
+  'super_admin',
+  'guest_house_admin',
+};
+
 final Map<String, Set<AppPermission>> rolePermissions = {
+  // Admin roles - have all permissions (backend admin bypass)
   'admin': AppPermission.values.toSet(),
-  'owner': AppPermission.values.toSet(),
+  'super_admin': AppPermission.values.toSet(),
+  'guest_house_admin': AppPermission.values.toSet(),
+
+  // Manager role
   'manager': {
     AppPermission.dashboard,
     AppPermission.bookings,
@@ -56,50 +71,102 @@ final Map<String, Set<AppPermission>> rolePermissions = {
     AppPermission.staff,
     AppPermission.assets,
   },
-  'technician': {
+
+  // Specialist roles
+  'maintenance': {
     AppPermission.dashboard,
     AppPermission.rooms,
     AppPermission.roomRates,
     AppPermission.assets,
   },
-  'reception': {
+  'receptionist': {
     AppPermission.dashboard,
     AppPermission.bookings,
     AppPermission.reservations,
     AppPermission.todos,
     AppPermission.settings,
   },
-  'cleaning': {
+  'housekeeping': {
     AppPermission.dashboard,
     AppPermission.rooms,
     AppPermission.todos,
   },
+  'finance': {
+    AppPermission.dashboard,
+    AppPermission.expenses,
+  },
+  'staff': {
+    AppPermission.dashboard,
+  },
+  'user': {
+    AppPermission.dashboard,
+  },
+  'guest': {
+    AppPermission.dashboard,
+  },
 };
 
 class Rbac {
+  /// Check if a user role has access to a specific permission.
+  ///
+  /// Admin roles ALWAYS have access (matches backend admin bypass logic).
+  /// Role comparison is case-insensitive (normalized to lowercase).
+  /// Returns true only if: role is admin OR role has explicit permission.
   static bool canAccess({
     required String role,
     required List<String> permissions,
     required AppPermission permission,
   }) {
-    if (permissions.isNotEmpty) {
-      return _permissionMatches(permissions, permission);
-    }
+    try {
+      if (role.isEmpty) return false;
 
-    final roleKey = role.toLowerCase();
-    final allowed = rolePermissions[roleKey];
-    if (allowed == null) {
+      // Normalize role to lowercase for comparison (backend roles are lowercase)
+      final normalizedRole = role.toLowerCase();
+
+      // Admin bypass: admins have access to EVERYTHING
+      // This matches backend behavior where admin is a super-role
+      if (_isAdminRole(normalizedRole)) {
+        return true;
+      }
+
+      // For non-admin roles, check explicit permissions list first
+      if (permissions.isNotEmpty) {
+        return _permissionMatches(permissions, permission);
+      }
+
+      // Fall back to role-based permissions mapping
+      final rolePermissionSet = rolePermissions[normalizedRole];
+      return rolePermissionSet?.contains(permission) ?? false;
+    } catch (_) {
+      // Fail safely - deny access on error
       return false;
     }
-    return allowed.contains(permission);
   }
 
-  static bool _permissionMatches(List<String> permissions, AppPermission permission) {
+  /// Check if a role string is an admin role (case-insensitive).
+  ///
+  /// Returns true for admin, super_admin, guest_house_admin.
+  static bool isAdmin(String role) {
+    if (role.isEmpty) return false;
+    return _isAdminRole(role.toLowerCase());
+  }
+
+  /// Internal helper: check if normalized role is admin (role should already be lowercase).
+  static bool _isAdminRole(String normalizedRole) {
+    return _adminRoles.contains(normalizedRole);
+  }
+
+  /// Match explicit permissions against required permission (case-insensitive).
+  static bool _permissionMatches(
+    List<String> permissions,
+    AppPermission permission,
+  ) {
     final key = permissionKeys[permission] ?? permission.name;
     final normalizedKey = key.toLowerCase();
-    final normalized = permissions.map((perm) => perm.toLowerCase());
-    return normalized.any(
-      (perm) => perm == normalizedKey || perm.contains(normalizedKey),
-    );
+
+    return permissions.any((perm) {
+      final normalizedPerm = perm.toLowerCase();
+      return normalizedPerm == normalizedKey || normalizedPerm.contains(normalizedKey);
+    });
   }
 }

--- a/lib/src/core/auth/rbac.dart
+++ b/lib/src/core/auth/rbac.dart
@@ -1,0 +1,105 @@
+enum AppPermission {
+  dashboard,
+  bookings,
+  reservations,
+  todos,
+  settings,
+  rooms,
+  roomRates,
+  expenses,
+  partnerHotels,
+  staff,
+  assets,
+}
+
+const Map<AppPermission, String> permissionKeys = {
+  AppPermission.dashboard: 'dashboard',
+  AppPermission.bookings: 'bookings',
+  AppPermission.reservations: 'reservations',
+  AppPermission.todos: 'todos',
+  AppPermission.settings: 'settings',
+  AppPermission.rooms: 'rooms',
+  AppPermission.roomRates: 'room_rates',
+  AppPermission.expenses: 'expenses',
+  AppPermission.partnerHotels: 'partner_hotels',
+  AppPermission.staff: 'staff',
+  AppPermission.assets: 'assets',
+};
+
+const Map<AppPermission, String> permissionLabels = {
+  AppPermission.dashboard: 'Dashboard',
+  AppPermission.bookings: 'Bookings',
+  AppPermission.reservations: 'Reservations',
+  AppPermission.todos: 'Todos',
+  AppPermission.settings: 'Settings',
+  AppPermission.rooms: 'Rooms',
+  AppPermission.roomRates: 'Room Rates',
+  AppPermission.expenses: 'Expenses',
+  AppPermission.partnerHotels: 'Partner Hotels',
+  AppPermission.staff: 'Guest Staff',
+  AppPermission.assets: 'Assets',
+};
+
+final Map<String, Set<AppPermission>> rolePermissions = {
+  'admin': AppPermission.values.toSet(),
+  'owner': AppPermission.values.toSet(),
+  'manager': {
+    AppPermission.dashboard,
+    AppPermission.bookings,
+    AppPermission.reservations,
+    AppPermission.todos,
+    AppPermission.settings,
+    AppPermission.rooms,
+    AppPermission.roomRates,
+    AppPermission.expenses,
+    AppPermission.partnerHotels,
+    AppPermission.staff,
+    AppPermission.assets,
+  },
+  'technician': {
+    AppPermission.dashboard,
+    AppPermission.rooms,
+    AppPermission.roomRates,
+    AppPermission.assets,
+  },
+  'reception': {
+    AppPermission.dashboard,
+    AppPermission.bookings,
+    AppPermission.reservations,
+    AppPermission.todos,
+    AppPermission.settings,
+  },
+  'cleaning': {
+    AppPermission.dashboard,
+    AppPermission.rooms,
+    AppPermission.todos,
+  },
+};
+
+class Rbac {
+  static bool canAccess({
+    required String role,
+    required List<String> permissions,
+    required AppPermission permission,
+  }) {
+    if (permissions.isNotEmpty) {
+      return _permissionMatches(permissions, permission);
+    }
+
+    final roleKey = role.toLowerCase();
+    final allowed = rolePermissions[roleKey];
+    if (allowed == null) {
+      return false;
+    }
+    return allowed.contains(permission);
+  }
+
+  static bool _permissionMatches(List<String> permissions, AppPermission permission) {
+    final key = permissionKeys[permission] ?? permission.name;
+    final normalizedKey = key.toLowerCase();
+    final normalized = permissions.map((perm) => perm.toLowerCase());
+    return normalized.any(
+      (perm) => perm == normalizedKey || perm.contains(normalizedKey),
+    );
+  }
+}

--- a/lib/src/core/auth/rbac.dart
+++ b/lib/src/core/auth/rbac.dart
@@ -95,9 +95,25 @@ final Map<String, Set<AppPermission>> rolePermissions = {
     AppPermission.dashboard,
     AppPermission.expenses,
   },
+
+  /// STAFF ROLE - VIEW-ONLY ACCESS
+  /// IMPORTANT: Staff can see all pages and data, but CANNOT modify anything.
+  /// All create/update/delete operations must be blocked at UI and API level.
+  /// See staff_enforcement.dart for UI guard utilities.
   'staff': {
     AppPermission.dashboard,
+    AppPermission.bookings,
+    AppPermission.reservations,
+    AppPermission.todos,
+    AppPermission.settings,
+    AppPermission.rooms,
+    AppPermission.roomRates,
+    AppPermission.expenses,
+    AppPermission.partnerHotels,
+    AppPermission.staff,
+    AppPermission.assets,
   },
+
   'user': {
     AppPermission.dashboard,
   },
@@ -154,6 +170,19 @@ class Rbac {
   /// Internal helper: check if normalized role is admin (role should already be lowercase).
   static bool _isAdminRole(String normalizedRole) {
     return _adminRoles.contains(normalizedRole);
+  }
+
+  /// Check if a role can perform mutations (create, update, delete).
+  /// Returns false for STAFF (view-only), true for all others.
+  ///
+  /// Usage: Hide/disable mutation UI if !Rbac.canMutate(role)
+  static bool canMutate(String role) {
+    if (role.isEmpty) return false;
+    final normalized = role.toLowerCase();
+    // Staff cannot mutate - view-only access
+    if (normalized == 'staff') return false;
+    // All other roles can mutate
+    return true;
   }
 
   /// Match explicit permissions against required permission (case-insensitive).

--- a/lib/src/features/auth/login_screen.dart
+++ b/lib/src/features/auth/login_screen.dart
@@ -64,7 +64,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     ref.listen(authProvider, (previous, next) {
       next.when(
         loading: () {},
-        authenticated: (_) {
+        authenticated: (_, __, ___) {
           // The moment login succeeds, we force the screen to change
           if (mounted) {
             Navigator.of(context).pushReplacement(
@@ -161,7 +161,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                     final authState = ref.watch(authProvider);
                     final isLoading = authState.when(
                       loading: () => true,
-                      authenticated: (_) => false,
+                      authenticated: (_, __, ___) => false,
                       unauthenticated: () => false,
                       error: (_) => false,
                     );

--- a/lib/src/features/auth/register_screen.dart
+++ b/lib/src/features/auth/register_screen.dart
@@ -69,7 +69,7 @@ class RegisterScreen extends ConsumerWidget {
                     final authState = ref.watch(authProvider);
                     final isLoading = authState.when(
                       loading: () => true,
-                      authenticated: (_) => false,
+                      authenticated: (_, __, ___) => false,
                       unauthenticated: () => false,
                       error: (_) => false,
                     );

--- a/lib/src/features/home/assets/add_asset_screen.dart
+++ b/lib/src/features/home/assets/add_asset_screen.dart
@@ -3,8 +3,10 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:intl/intl.dart';
+import 'package:Zonova_Mist/src/core/auth/rbac.dart';
 import 'package:Zonova_Mist/src/features/home/assets/models/asset_model.dart';
 import 'package:Zonova_Mist/src/features/home/assets/providers/asset_provider.dart';
+import 'package:Zonova_Mist/src/shared/widgets/rbac_gate.dart';
 
 class AddAssetScreen extends ConsumerStatefulWidget {
   const AddAssetScreen({super.key});
@@ -61,17 +63,19 @@ class _AddAssetScreenState extends ConsumerState<AddAssetScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Add New Asset'),
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
-        child: FormBuilder(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
+    return RbacGate(
+      permission: AppPermission.assets,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Add New Asset'),
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16.0),
+          child: FormBuilder(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
               FormBuilderTextField(
                 name: 'name',
                 decoration: const InputDecoration(labelText: 'Asset Name'),
@@ -135,7 +139,8 @@ class _AddAssetScreenState extends ConsumerState<AddAssetScreen> {
                     ? const SizedBox(height: 20, width: 20, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white,))
                     : const Text('Save Asset'),
               ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/home/assets/asset_details_screen.dart
+++ b/lib/src/features/home/assets/asset_details_screen.dart
@@ -1,9 +1,11 @@
 
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:Zonova_Mist/src/core/auth/rbac.dart';
 import 'package:Zonova_Mist/src/features/home/assets/models/asset_model.dart';
 import 'package:Zonova_Mist/src/shared/widgets/common_image_manager.dart';
 import 'package:Zonova_Mist/src/features/home/assets/edit_asset_screen.dart';
+import 'package:Zonova_Mist/src/shared/widgets/rbac_gate.dart';
 
 class AssetDetailsScreen extends StatelessWidget {
   final AssetModel asset;
@@ -12,55 +14,58 @@ class AssetDetailsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(asset.name),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.edit),
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => EditAssetScreen(asset: asset),
-                ),
-              );
-            },
-          ),
-        ],
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Photo Management Section
-            _buildPhotoSection(context),
-            const SizedBox(height: 24),
-
-            // Asset Details
-            _buildDetailSection(context, 'Asset Details', [
-              _buildDetailRow('Category', asset.category),
-              _buildDetailRow('Brand', asset.brand ?? 'N/A'),
-              _buildDetailRow('Quantity', asset.quantity.toString()),
-            ]),
-            const SizedBox(height: 24),
-
-            // Purchase Information
-            _buildDetailSection(context, 'Purchase Information', [
-              _buildDetailRow('Purchase Price', NumberFormat.currency(locale: 'en_LK', symbol: 'Rs. ').format(asset.purchasePrice)),
-              _buildDetailRow('Purchase Date', DateFormat.yMMMd().format(asset.purchaseDate)),
-            ]),
-            const SizedBox(height: 24),
-
-            // Warranty Information
-            if (asset.warrantyEndDate != null)
-              _buildWarrantySection(context),
-
-            // Description
-            if (asset.description != null && asset.description!.isNotEmpty)
-              _buildDescriptionSection(context),
+    return RbacGate(
+      permission: AppPermission.assets,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(asset.name),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.edit),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => EditAssetScreen(asset: asset),
+                  ),
+                );
+              },
+            ),
           ],
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Photo Management Section
+              _buildPhotoSection(context),
+              const SizedBox(height: 24),
+
+              // Asset Details
+              _buildDetailSection(context, 'Asset Details', [
+                _buildDetailRow('Category', asset.category),
+                _buildDetailRow('Brand', asset.brand ?? 'N/A'),
+                _buildDetailRow('Quantity', asset.quantity.toString()),
+              ]),
+              const SizedBox(height: 24),
+
+              // Purchase Information
+              _buildDetailSection(context, 'Purchase Information', [
+                _buildDetailRow('Purchase Price', NumberFormat.currency(locale: 'en_LK', symbol: 'Rs. ').format(asset.purchasePrice)),
+                _buildDetailRow('Purchase Date', DateFormat.yMMMd().format(asset.purchaseDate)),
+              ]),
+              const SizedBox(height: 24),
+
+              // Warranty Information
+              if (asset.warrantyEndDate != null)
+                _buildWarrantySection(context),
+
+              // Description
+              if (asset.description != null && asset.description!.isNotEmpty)
+                _buildDescriptionSection(context),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/home/assets/asset_group_screen.dart
+++ b/lib/src/features/home/assets/asset_group_screen.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:intl/intl.dart';
+import 'package:Zonova_Mist/src/core/auth/rbac.dart';
 import 'package:Zonova_Mist/src/features/home/assets/models/asset_model.dart';
 import 'package:Zonova_Mist/src/features/home/assets/asset_details_screen.dart';
 import 'package:Zonova_Mist/src/features/home/assets/providers/asset_provider.dart';
+import 'package:Zonova_Mist/src/shared/widgets/rbac_gate.dart';
 
 class AssetGroupScreen extends ConsumerWidget { // Changed to ConsumerWidget
   final String groupName;
@@ -37,7 +39,9 @@ class AssetGroupScreen extends ConsumerWidget { // Changed to ConsumerWidget
       });
     }
 
-    return Scaffold(
+    return RbacGate(
+      permission: AppPermission.assets,
+      child: Scaffold(
       appBar: AppBar(
         title: Text(groupName),
       ),
@@ -110,7 +114,7 @@ class AssetGroupScreen extends ConsumerWidget { // Changed to ConsumerWidget
           );
         },
       ),
+      ),
     );
   }
 }
-

--- a/lib/src/features/home/assets/asset_screen.dart
+++ b/lib/src/features/home/assets/asset_screen.dart
@@ -3,11 +3,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:collection/collection.dart'; // Import the collection package
 
+import 'package:Zonova_Mist/src/core/auth/rbac.dart';
 import 'package:Zonova_Mist/src/features/home/assets/providers/asset_provider.dart';
 import 'package:Zonova_Mist/src/features/home/assets/models/asset_model.dart';
 import 'package:Zonova_Mist/src/features/home/assets/asset_details_screen.dart';
 import 'package:Zonova_Mist/src/features/home/assets/add_asset_screen.dart';
 import 'package:Zonova_Mist/src/features/home/assets/asset_group_screen.dart';
+import 'package:Zonova_Mist/src/shared/widgets/rbac_gate.dart';
 
 class AssetsScreen extends ConsumerWidget {
   const AssetsScreen({super.key});
@@ -16,68 +18,70 @@ class AssetsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final assetsAsyncValue = ref.watch(assetsProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Assets'),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (context) => const AddAssetScreen()),
-          );
-        },
-        child: const Icon(Icons.add),
-      ),
-      body: assetsAsyncValue.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stackTrace) => Center(
-          child: Text(
-            'Failed to load assets.\nPlease try again later.\n\nError: $error',
-            textAlign: TextAlign.center,
-          ),
+    return RbacGate(
+      permission: AppPermission.assets,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Assets'),
         ),
-        data: (assets) {
-          // Calculate the total value and total quantity of all assets
-          final totalValue = assets.fold<double>(0, (sum, item) => sum + (item.purchasePrice * item.quantity));
-          final totalQuantity = assets.fold<int>(0, (sum, item) => sum + item.quantity);
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => const AddAssetScreen()),
+            );
+          },
+          child: const Icon(Icons.add),
+        ),
+        body: assetsAsyncValue.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, stackTrace) => Center(
+            child: Text(
+              'Failed to load assets.\nPlease try again later.\n\nError: $error',
+              textAlign: TextAlign.center,
+            ),
+          ),
+          data: (assets) {
+            // Calculate the total value and total quantity of all assets
+            final totalValue = assets.fold<double>(0, (sum, item) => sum + (item.purchasePrice * item.quantity));
+            final totalQuantity = assets.fold<int>(0, (sum, item) => sum + item.quantity);
 
-          // Group assets by name
-          final groupedAssets = groupBy(assets, (AssetModel asset) => asset.name);
+            // Group assets by name
+            final groupedAssets = groupBy(assets, (AssetModel asset) => asset.name);
 
-          return RefreshIndicator(
-            onRefresh: () => ref.read(assetsProvider.notifier).loadAssets(),
-            child: ListView(
-              padding: const EdgeInsets.all(16.0),
-              children: [
-                GridView.count(
-                  crossAxisCount: 2,
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  mainAxisSpacing: 12,
-                  crossAxisSpacing: 12,
-                  childAspectRatio: 2.2,
-                  children: [
-                    _buildStatCard(
-                      title: 'Total Quantity', // <-- Changed from Total Assets
-                      value: totalQuantity.toString(),
-                      icon: Icons.business_center,
-                      color: Colors.blue.shade700,
-                    ),
-                    _buildStatCard(
-                      title: 'Total Value',
-                      value: NumberFormat.currency(locale: 'en_LK', symbol: 'Rs.').format(totalValue),
-                      icon: Icons.account_balance_wallet,
-                      color: Colors.green.shade700,
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 24),
-                Text(
-                  'Asset Groups', // <-- Changed from All Assets
-                  style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 12),
+            return RefreshIndicator(
+              onRefresh: () => ref.read(assetsProvider.notifier).loadAssets(),
+              child: ListView(
+                padding: const EdgeInsets.all(16.0),
+                children: [
+                  GridView.count(
+                    crossAxisCount: 2,
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    mainAxisSpacing: 12,
+                    crossAxisSpacing: 12,
+                    childAspectRatio: 2.2,
+                    children: [
+                      _buildStatCard(
+                        title: 'Total Quantity', // <-- Changed from Total Assets
+                        value: totalQuantity.toString(),
+                        icon: Icons.business_center,
+                        color: Colors.blue.shade700,
+                      ),
+                      _buildStatCard(
+                        title: 'Total Value',
+                        value: NumberFormat.currency(locale: 'en_LK', symbol: 'Rs.').format(totalValue),
+                        icon: Icons.account_balance_wallet,
+                        color: Colors.green.shade700,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Asset Groups', // <-- Changed from All Assets
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 12),
                 if (assets.isEmpty)
                   const Center(
                     child: Padding(
@@ -87,10 +91,11 @@ class AssetsScreen extends ConsumerWidget {
                   )
                 else
                   _buildGroupedAssetList(context, groupedAssets),
-              ],
-            ),
-          );
-        },
+                ],
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/src/features/home/assets/edit_asset_screen.dart
+++ b/lib/src/features/home/assets/edit_asset_screen.dart
@@ -3,8 +3,10 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:intl/intl.dart';
+import 'package:Zonova_Mist/src/core/auth/rbac.dart';
 import 'package:Zonova_Mist/src/features/home/assets/models/asset_model.dart';
 import 'package:Zonova_Mist/src/features/home/assets/providers/asset_provider.dart';
+import 'package:Zonova_Mist/src/shared/widgets/rbac_gate.dart';
 
 class EditAssetScreen extends ConsumerStatefulWidget {
   final AssetModel asset;
@@ -112,25 +114,27 @@ class _EditAssetScreenState extends ConsumerState<EditAssetScreen> {
       'warrantyDetails': widget.asset.warrantyDetails,
     };
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Edit Asset'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.delete_outline, color: Colors.red),
-            onPressed: _deleteAsset,
-            tooltip: 'Delete Asset',
-          ),
-        ],
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
-        child: FormBuilder(
-          key: _formKey,
-          initialValue: initialFormValues, // <-- The fix is here
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
+    return RbacGate(
+      permission: AppPermission.assets,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Edit Asset'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.delete_outline, color: Colors.red),
+              onPressed: _deleteAsset,
+              tooltip: 'Delete Asset',
+            ),
+          ],
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16.0),
+          child: FormBuilder(
+            key: _formKey,
+            initialValue: initialFormValues, // <-- The fix is here
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
               FormBuilderTextField(name: 'name', decoration: const InputDecoration(labelText: 'Asset Name'), validator: FormBuilderValidators.required()),
               const SizedBox(height: 16),
               FormBuilderDropdown(name: 'category', decoration: const InputDecoration(labelText: 'Category'), items: ['Furniture', 'Electronics', 'Appliances', 'Linens', 'Other'].map((c) => DropdownMenuItem(value: c, child: Text(c))).toList(), validator: FormBuilderValidators.required()),
@@ -153,7 +157,8 @@ class _EditAssetScreenState extends ConsumerState<EditAssetScreen> {
                 onPressed: _isSaving ? null : _submitForm,
                 child: _isSaving ? const SizedBox(height: 20, width: 20, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white,)) : const Text('Save Changes'),
               ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/home/bookings/add_booking_screen.dart
+++ b/lib/src/features/home/bookings/add_booking_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
 import '../../../shared/widgets/room_selector_widget.dart';
 import '../../../shared/widgets/common_image_manager.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 import '../../../shared/models/nic_data.dart';
 import 'package:intl/intl.dart';
 
@@ -458,46 +460,48 @@ class _AddBookingScreenState extends ConsumerState<AddBookingScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Add Booking'),
-        elevation: 0,
-        actions: [
-          if (_nicDataApplied)
-            Padding(
-              padding: const EdgeInsets.only(right: 16),
-              child: Center(
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                  decoration: BoxDecoration(
-                    color: Colors.green.shade100,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.verified, size: 16, color: Colors.green.shade700),
-                      const SizedBox(width: 4),
-                      Text(
-                        'NIC Applied',
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: Colors.green.shade700,
-                          fontWeight: FontWeight.w600,
+    return RbacGate(
+      permission: AppPermission.bookings,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Add Booking'),
+          elevation: 0,
+          actions: [
+            if (_nicDataApplied)
+              Padding(
+                padding: const EdgeInsets.only(right: 16),
+                child: Center(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: Colors.green.shade100,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.verified, size: 16, color: Colors.green.shade700),
+                        const SizedBox(width: 4),
+                        Text(
+                          'NIC Applied',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.green.shade700,
+                            fontWeight: FontWeight.w600,
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
               ),
-            ),
-        ],
-      ),
-      body: Form(
-        key: _formKey,
-        child: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
+          ],
+        ),
+        body: Form(
+          key: _formKey,
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
             _buildCard(
               title: "Guest Information",
               children: [
@@ -716,6 +720,7 @@ class _AddBookingScreenState extends ConsumerState<AddBookingScreen> {
             ),
             const SizedBox(height: 24),
           ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/home/bookings/bookings_screen.dart
+++ b/lib/src/features/home/bookings/bookings_screen.dart
@@ -3,8 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
 import '../../../shared/widgets/common_image_manager.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 import 'add_booking_screen.dart';
 import 'bookings_provider.dart';
 import 'edit_booking_screen.dart';
@@ -232,27 +234,29 @@ class BookingsScreen extends ConsumerWidget {
     final statusFilter = ref.watch(bookingStatusFilterProvider);
     final searchQuery = ref.watch(bookingSearchProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Bookings'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.search),
-            onPressed: () => _showSearchDialog(context, ref),
-          ),
-          IconButton(
-            icon: Badge(
-              isLabelVisible: currentFilter != 'upcoming' || statusFilter != 'advance_paid' || searchQuery.isNotEmpty,
-              label: const Text('•'),
-              child: const Icon(Icons.filter_list),
+    return RbacGate(
+      permission: AppPermission.bookings,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Bookings'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.search),
+              onPressed: () => _showSearchDialog(context, ref),
             ),
-            onPressed: () => _showFilterSheet(context, ref),
-          ),
-        ],
-      ),
-      drawer: const AppDrawer(),
-      body: Column(
-        children: [
+            IconButton(
+              icon: Badge(
+                isLabelVisible: currentFilter != 'upcoming' || statusFilter != 'advance_paid' || searchQuery.isNotEmpty,
+                label: const Text('•'),
+                child: const Icon(Icons.filter_list),
+              ),
+              onPressed: () => _showFilterSheet(context, ref),
+            ),
+          ],
+        ),
+        drawer: const AppDrawer(),
+        body: Column(
+          children: [
           // Active Filter Chips
           if (currentFilter != 'upcoming' || statusFilter != 'advance_paid' || searchQuery.isNotEmpty)
             Container(
@@ -542,20 +546,21 @@ class BookingsScreen extends ConsumerWidget {
               ),
             ),
           ),
-        ],
-      ),
-      floatingActionButton: FloatingActionButton(
-        heroTag: 'add_booking_fab',
-        onPressed: () async {
-          final result = await Navigator.push(
-            context,
-            MaterialPageRoute(builder: (_) => const AddBookingScreen()),
-          );
-          if (result == true) {
-            ref.refresh(bookingsProvider);
-          }
-        },
-        child: const Icon(Icons.add),
+          ],
+        ),
+        floatingActionButton: FloatingActionButton(
+          heroTag: 'add_booking_fab',
+          onPressed: () async {
+            final result = await Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const AddBookingScreen()),
+            );
+            if (result == true) {
+              ref.refresh(bookingsProvider);
+            }
+          },
+          child: const Icon(Icons.add),
+        ),
       ),
     );
   }

--- a/lib/src/features/home/bookings/create_invoice_screen.dart
+++ b/lib/src/features/home/bookings/create_invoice_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class CreateInvoiceScreen extends ConsumerStatefulWidget {
   final String bookingId;
@@ -59,47 +61,50 @@ class _CreateInvoiceScreenState extends ConsumerState<CreateInvoiceScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Create Invoice')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            children: [
-              Text('Guest: ${widget.guestName}', style: const TextStyle(fontSize: 18)),
-              Text('Phone: ${widget.phone}', style: const TextStyle(fontSize: 16)),
-              const SizedBox(height: 20),
-              TextFormField(
-                controller: _roomChargeController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: 'Room Charge'),
-              ),
-              TextFormField(
-                controller: _foodChargeController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: 'Food Charge'),
-              ),
-              TextFormField(
-                controller: _otherChargeController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: 'Other Charges'),
-              ),
-              TextFormField(
-                controller: _totalController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: 'Total'),
-              ),
-              const SizedBox(height: 25),
-              ElevatedButton.icon(
-                onPressed: _isSending ? null : _sendInvoice,
-                icon: const Icon(Icons.send),
-                label: _isSending
-                    ? const CircularProgressIndicator(color: Colors.white)
-                    : const Text('Send Invoice via SMS'),
-                style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
-              ),
-            ],
+    return RbacGate(
+      permission: AppPermission.bookings,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Create Invoice')),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              children: [
+                Text('Guest: ${widget.guestName}', style: const TextStyle(fontSize: 18)),
+                Text('Phone: ${widget.phone}', style: const TextStyle(fontSize: 16)),
+                const SizedBox(height: 20),
+                TextFormField(
+                  controller: _roomChargeController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: 'Room Charge'),
+                ),
+                TextFormField(
+                  controller: _foodChargeController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: 'Food Charge'),
+                ),
+                TextFormField(
+                  controller: _otherChargeController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: 'Other Charges'),
+                ),
+                TextFormField(
+                  controller: _totalController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: 'Total'),
+                ),
+                const SizedBox(height: 25),
+                ElevatedButton.icon(
+                  onPressed: _isSending ? null : _sendInvoice,
+                  icon: const Icon(Icons.send),
+                  label: _isSending
+                      ? const CircularProgressIndicator(color: Colors.white)
+                      : const Text('Send Invoice via SMS'),
+                  style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/home/bookings/edit_booking_screen.dart
+++ b/lib/src/features/home/bookings/edit_booking_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
 import '../../../shared/widgets/room_selector_widget.dart';
 import '../../../shared/widgets/common_image_manager.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 import '../../../shared/models/nic_data.dart';
 import 'bookings_provider.dart';
 import 'package:intl/intl.dart';
@@ -519,43 +521,45 @@ class _EditBookingScreenState extends ConsumerState<EditBookingScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text("Edit Booking"),
-        elevation: 0,
-        actions: [
-          if (_nicDataApplied)
-            Padding(
-              padding: const EdgeInsets.only(right: 16),
-              child: Center(
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                  decoration: BoxDecoration(
-                    color: Colors.green.shade100,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.verified, size: 16, color: Colors.green.shade700),
-                      const SizedBox(width: 4),
-                      Text(
-                        'NIC Applied',
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: Colors.green.shade700,
-                          fontWeight: FontWeight.w600,
+    return RbacGate(
+      permission: AppPermission.bookings,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text("Edit Booking"),
+          elevation: 0,
+          actions: [
+            if (_nicDataApplied)
+              Padding(
+                padding: const EdgeInsets.only(right: 16),
+                child: Center(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: Colors.green.shade100,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.verified, size: 16, color: Colors.green.shade700),
+                        const SizedBox(width: 4),
+                        Text(
+                          'NIC Applied',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.green.shade700,
+                            fontWeight: FontWeight.w600,
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
               ),
-            ),
-        ],
-      ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
+          ],
+        ),
+        body: ListView(
+          padding: const EdgeInsets.all(16),
         children: [
           _buildCard(
             title: "Guest Information",
@@ -769,6 +773,7 @@ class _EditBookingScreenState extends ConsumerState<EditBookingScreen> {
           ),
           const SizedBox(height: 24),
         ],
+        ),
       ),
     );
   }

--- a/lib/src/features/home/bookings/invoice_form_screen.dart
+++ b/lib/src/features/home/bookings/invoice_form_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class InvoiceFormScreen extends ConsumerStatefulWidget {
   final Map<String, dynamic> booking;
@@ -103,18 +105,20 @@ class _InvoiceFormScreenState extends ConsumerState<InvoiceFormScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Generate Invoice'),
-        elevation: 0,
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
+    return RbacGate(
+      permission: AppPermission.bookings,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Generate Invoice'),
+          elevation: 0,
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
               // Guest Info Card
               Card(
                 color: Colors.blue.shade50,
@@ -312,7 +316,8 @@ class _InvoiceFormScreenState extends ConsumerState<InvoiceFormScreen> {
                   textAlign: TextAlign.center,
                 ),
               ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/home/dashboard/dashboard_screen.dart
+++ b/lib/src/features/home/dashboard/dashboard_screen.dart
@@ -2,7 +2,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../shared/widgets/app_drawer.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 import 'providers/dashboard_provider.dart';
 import 'models/dashboard_models.dart';
 import 'widgets/stat_panel.dart';
@@ -19,73 +21,76 @@ class DashboardScreen extends ConsumerWidget {
     final dashboardState = ref.watch(dashboardProvider);
     final notifier = ref.read(dashboardProvider.notifier);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Dashboard'),
-        elevation: 0,
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            tooltip: 'Refresh',
-            onPressed: () {
-              // Trigger refresh
-              ref.invalidate(dashboardProvider);
-            },
-          ),
-        ],
-      ),
-      drawer: const AppDrawer(),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Welcome Card
-            _buildWelcomeCard(),
-            const SizedBox(height: 24),
-
-            // Filter Chips
-            FilterChipsRow(
-              timePeriod: dashboardState.timePeriod,
-              selectedComparisons: dashboardState.selectedComparisons,
-              onTimePeriodChanged: notifier.setTimePeriod,
-              onComparisonToggled: notifier.toggleComparison,
-              onCustomDatePressed: () => _showDateRangePicker(context, ref),
+    return RbacGate(
+      permission: AppPermission.dashboard,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Dashboard'),
+          elevation: 0,
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: 'Refresh',
+              onPressed: () {
+                // Trigger refresh
+                ref.invalidate(dashboardProvider);
+              },
             ),
-            const SizedBox(height: 24),
-
-            // Stat Panel
-            StatPanel(stats: notifier.getStatPanelData()),
-            const SizedBox(height: 24),
-
-            // Revenue Comparison Chart
-            _buildSectionTitle('Revenue Comparison'),
-            const SizedBox(height: 12),
-            RevenueComparisonChart(
-              data: notifier.getRevenueComparisonData(),
-              selectedComparisons: dashboardState.selectedComparisons,
-              timePeriod: dashboardState.timePeriod,
-            ),
-            const SizedBox(height: 24),
-
-            // Expense Comparison Chart
-            _buildSectionTitle('Expense Comparison'),
-            const SizedBox(height: 12),
-            ExpenseComparisonChart(
-              data: notifier.getExpenseComparisonData(),
-              selectedComparisons: dashboardState.selectedComparisons,
-              timePeriod: dashboardState.timePeriod,
-            ),
-            const SizedBox(height: 24),
-
-            // Expense Category Chart
-            _buildSectionTitle('Expenses by Category'),
-            const SizedBox(height: 12),
-            ExpenseCategoryChart(
-              data: notifier.getExpenseCategoryData(),
-            ),
-            const SizedBox(height: 24),
           ],
+        ),
+        drawer: const AppDrawer(),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Welcome Card
+              _buildWelcomeCard(),
+              const SizedBox(height: 24),
+
+              // Filter Chips
+              FilterChipsRow(
+                timePeriod: dashboardState.timePeriod,
+                selectedComparisons: dashboardState.selectedComparisons,
+                onTimePeriodChanged: notifier.setTimePeriod,
+                onComparisonToggled: notifier.toggleComparison,
+                onCustomDatePressed: () => _showDateRangePicker(context, ref),
+              ),
+              const SizedBox(height: 24),
+
+              // Stat Panel
+              StatPanel(stats: notifier.getStatPanelData()),
+              const SizedBox(height: 24),
+
+              // Revenue Comparison Chart
+              _buildSectionTitle('Revenue Comparison'),
+              const SizedBox(height: 12),
+              RevenueComparisonChart(
+                data: notifier.getRevenueComparisonData(),
+                selectedComparisons: dashboardState.selectedComparisons,
+                timePeriod: dashboardState.timePeriod,
+              ),
+              const SizedBox(height: 24),
+
+              // Expense Comparison Chart
+              _buildSectionTitle('Expense Comparison'),
+              const SizedBox(height: 12),
+              ExpenseComparisonChart(
+                data: notifier.getExpenseComparisonData(),
+                selectedComparisons: dashboardState.selectedComparisons,
+                timePeriod: dashboardState.timePeriod,
+              ),
+              const SizedBox(height: 24),
+
+              // Expense Category Chart
+              _buildSectionTitle('Expenses by Category'),
+              const SizedBox(height: 12),
+              ExpenseCategoryChart(
+                data: notifier.getExpenseCategoryData(),
+              ),
+              const SizedBox(height: 24),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/home/expenses/add_expense_page.dart
+++ b/lib/src/features/home/expenses/add_expense_page.dart
@@ -3,6 +3,8 @@ import 'package:image_picker/image_picker.dart';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:Zonova_Mist/enums/expense_category.dart';
+import '../../../core/auth/rbac.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 
 class AddExpensePage extends StatefulWidget {
@@ -132,15 +134,17 @@ class _AddExpensePageState extends State<AddExpensePage> {
         .map((e) => e.displayName)
         .toList();
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Add Expense')),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
+    return RbacGate(
+      permission: AppPermission.expenses,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Add Expense')),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
               // Category dropdown field
               DropdownButtonFormField<String>(
                 value: _category,
@@ -370,7 +374,8 @@ class _AddExpensePageState extends State<AddExpensePage> {
                 )
                     : const Text('Add Expense'),
               ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/home/expenses/edit_expense_page.dart
+++ b/lib/src/features/home/expenses/edit_expense_page.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:image_picker/image_picker.dart';
+import '../../../core/auth/rbac.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 /// Edit Expense Page - Allows users to modify existing expense entries
 /// Users can update expense details and manage attached images
@@ -308,15 +310,17 @@ class _EditExpensePageState extends State<EditExpensePage> {
     final expenseId = widget.expense['id'] ?? widget.expense['_id'] ?? '';
     final hasImages = _existing.isNotEmpty || _newPicked.isNotEmpty;
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Edit Expense')),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
+    return RbacGate(
+      permission: AppPermission.expenses,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Edit Expense')),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
               // Category dropdown field
               DropdownButtonFormField<String>(
                 value: categories.contains(_category) ? _category : null,
@@ -574,7 +578,8 @@ class _EditExpensePageState extends State<EditExpensePage> {
                 ),
                 child: const Text('Update Expense'),
               ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/home/expenses/expenses_list_page.dart
+++ b/lib/src/features/home/expenses/expenses_list_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../../services/expense_service.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 import 'add_expense_page.dart';
 import 'edit_expense_page.dart';
 import 'view_expense_page.dart';
@@ -210,7 +212,9 @@ class _ExpensesListPageState extends ConsumerState<ExpensesListPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return RbacGate(
+      permission: AppPermission.expenses,
+      child: Scaffold(
       appBar: AppBar(
         title: const Text('Expenses'),
         actions: [
@@ -343,6 +347,7 @@ class _ExpensesListPageState extends ConsumerState<ExpensesListPage> {
       floatingActionButton: FloatingActionButton(
         onPressed: _openAdd,
         child: const Icon(Icons.add),
+      ),
       ),
     );
   }

--- a/lib/src/features/home/expenses/view_expense_page.dart
+++ b/lib/src/features/home/expenses/view_expense_page.dart
@@ -2,8 +2,10 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import 'edit_expense_page.dart';
 import '../../../../services/expense_service.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class ViewExpensePage extends ConsumerWidget {
   // Expense data to display
@@ -112,7 +114,9 @@ class ViewExpensePage extends ConsumerWidget {
       }
     }
 
-    return Scaffold(
+    return RbacGate(
+      permission: AppPermission.expenses,
+      child: Scaffold(
       appBar: AppBar(
         title: const Text('Expense Details'),
         actions: [

--- a/lib/src/features/home/expenses/view_expense_page.dart
+++ b/lib/src/features/home/expenses/view_expense_page.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,6 +5,7 @@ import '../../../core/auth/rbac.dart';
 import 'edit_expense_page.dart';
 import '../../../../services/expense_service.dart';
 import '../../../shared/widgets/rbac_gate.dart';
+import '../../../shared/widgets/platform_image_stub.dart';
 
 class ViewExpensePage extends ConsumerWidget {
   // Expense data to display
@@ -107,8 +107,10 @@ class ViewExpensePage extends ConsumerWidget {
     if (imageFiles is List && imageFiles.isNotEmpty) {
       for (var file in imageFiles) {
         try {
-          if (file != null && file.path != null) {
-            imageUrls.add(file.path.toString());
+          // Some items might be XFile or PlatformFile, guard against missing path
+          final path = file?.path ?? file?.toString();
+          if (path != null && path.isNotEmpty) {
+            imageUrls.add(path.toString());
           }
         } catch (_) {}
       }
@@ -117,200 +119,118 @@ class ViewExpensePage extends ConsumerWidget {
     return RbacGate(
       permission: AppPermission.expenses,
       child: Scaffold(
-      appBar: AppBar(
-        title: const Text('Expense Details'),
-        actions: [
-          // Edit button - opens edit page
-          IconButton(
-            icon: const Icon(Icons.edit),
-            onPressed: () async {
-              final res = await Navigator.push<Map<String, dynamic>>(
-                context,
-                MaterialPageRoute(builder: (_) => EditExpensePage(expense: expense)),
-              );
+        appBar: AppBar(
+          title: const Text('Expense Details'),
+          actions: [
+            // Edit button - opens edit page
+            IconButton(
+              icon: const Icon(Icons.edit),
+              onPressed: () async {
+                final res = await Navigator.push<Map<String, dynamic>>(
+                  context,
+                  MaterialPageRoute(builder: (_) => EditExpensePage(expense: expense)),
+                );
 
-              // ✅ If data returned, update via API
-              if (res != null && context.mounted) {
-                try {
-                  final expenseService = ref.read(expenseServiceProvider);
-                  final updated = await expenseService.updateExpense(expense['id'], res);
+                // ✅ If data returned, update via API
+                if (res != null && context.mounted) {
+                  try {
+                    final expenseService = ref.read(expenseServiceProvider);
+                    final updated = await expenseService.updateExpense(expense['id'], res);
 
-                  // Show success message
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('✅ Expense updated'),
-                        backgroundColor: Colors.green,
-                      ),
-                    );
+                    // Show success message
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('✅ Expense updated'),
+                          backgroundColor: Colors.green,
+                        ),
+                      );
 
-                    // Return updated data to ListPage
-                    Navigator.pop(context, {...updated, 'id': updated['_id'] ?? updated['id']});
-                  }
-                } catch (err) {
-                  // Show error message if update fails
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('❌ Update failed: $err'),
-                        backgroundColor: Colors.red,
-                      ),
-                    );
+                      // Return updated data to ListPage
+                      Navigator.pop(context, {...updated, 'id': updated['_id'] ?? updated['id']});
+                    }
+                  } catch (err) {
+                    // Show error message if update fails
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('❌ Update failed: $err'),
+                          backgroundColor: Colors.red,
+                        ),
+                      );
+                    }
                   }
                 }
-              }
-            },
-          ),
-        ],
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // Header Section - Shows expense title and category with visual styling
-            Card(
-              elevation: 4,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  children: [
-                    // Category icon with colored background
-                    CircleAvatar(
-                      radius: 60,
-                      backgroundColor: _getCategoryColor(category).withOpacity(0.2),
-                      child: Icon(
-                        Icons.receipt_long,
-                        size: 60,
-                        color: _getCategoryColor(category),
-                      ),
-                    ),
-                    const SizedBox(height: 16),
-                    // Expense title
-                    Text(
-                      title,
-                      style: const TextStyle(
-                        fontSize: 24,
-                        fontWeight: FontWeight.bold,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 8),
-                    // Category badge with colored border
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 8,
-                      ),
-                      decoration: BoxDecoration(
-                        color: _getCategoryColor(category).withOpacity(0.1),
-                        borderRadius: BorderRadius.circular(20),
-                        border: Border.all(
+              },
+            ),
+          ],
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Header Section - Shows expense title and category with visual styling
+              Card(
+                elevation: 4,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Column(
+                    children: [
+                      // Category icon with colored background
+                      CircleAvatar(
+                        radius: 60,
+                        backgroundColor: _getCategoryColor(category).withAlpha((0.2 * 255).round()),
+                        child: Icon(
+                          Icons.receipt_long,
+                          size: 60,
                           color: _getCategoryColor(category),
-                          width: 2,
                         ),
                       ),
-                      child: Text(
-                        category,
-                        style: TextStyle(
-                          fontSize: 16,
+                      const SizedBox(height: 16),
+                      // Expense title
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          fontSize: 24,
                           fontWeight: FontWeight.bold,
-                          color: _getCategoryColor(category),
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 8),
+                      // Category badge with colored border
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
+                        ),
+                        decoration: BoxDecoration(
+                          color: _getCategoryColor(category).withAlpha((0.1 * 255).round()),
+                          borderRadius: BorderRadius.circular(20),
+                          border: Border.all(
+                            color: _getCategoryColor(category),
+                            width: 2,
+                          ),
+                        ),
+                        child: Text(
+                          category,
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: _getCategoryColor(category),
+                          ),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(height: 20),
+              const SizedBox(height: 20),
 
-            // Details Section - Shows date and description
-            Card(
-              elevation: 2,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Date Section - Icon, label and value
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Icon(Icons.calendar_today, color: Colors.blue.shade700, size: 20),
-                        const SizedBox(width: 8),
-                        const Text(
-                          'Date',
-                          style: TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        const Spacer(),
-                        // Display date or fallback message
-                        Flexible(
-                          child: displayDate.isNotEmpty
-                              ? Text(
-                            displayDate,
-                            style: const TextStyle(fontSize: 16),
-                            textAlign: TextAlign.right,
-                          )
-                              : Text(
-                            'No date provided',
-                            style: TextStyle(color: Colors.grey.shade600, fontSize: 16),
-                            textAlign: TextAlign.right,
-                          ),
-                        ),
-                      ],
-                    ),
-
-                    const Divider(height: 32),
-
-                    // Description Section - Icon, label and value
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Icon(Icons.notes, color: Colors.blue.shade700, size: 20),
-                        const SizedBox(width: 8),
-                        const Text(
-                          'Description',
-                          style: TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        const Spacer(),
-                        // Display description or fallback message
-                        Flexible(
-                          child: description.isNotEmpty
-                              ? Text(
-                            description,
-                            style: const TextStyle(fontSize: 16),
-                            textAlign: TextAlign.right,
-                          )
-                              : Text(
-                            'No description provided',
-                            style: TextStyle(color: Colors.grey.shade600, fontSize: 16),
-                            textAlign: TextAlign.right,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            const SizedBox(height: 16),
-
-            // Bill & Receipt Images Section - Shows grid of attached images
-            // Only displayed if images are available
-            if (imageUrls.isNotEmpty)
+              // Details Section - Shows date and description
               Card(
                 elevation: 2,
                 shape: RoundedRectangleBorder(
@@ -321,78 +241,162 @@ class ViewExpensePage extends ConsumerWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      // Section header
+                      // Date Section - Icon, label and value
                       Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Icon(Icons.receipt_long, color: Colors.blue.shade700),
-                          const SizedBox(width: 5),
+                          Icon(Icons.calendar_today, color: Colors.blue.shade700, size: 20),
+                          const SizedBox(width: 8),
                           const Text(
-                            'Bill & Receipt',
+                            'Date',
                             style: TextStyle(
-                              fontSize: 18,
+                              fontSize: 16,
                               fontWeight: FontWeight.bold,
                             ),
                           ),
+                          const Spacer(),
+                          // Display date or fallback message
+                          Flexible(
+                            child: displayDate.isNotEmpty
+                                ? Text(
+                                    displayDate,
+                                    style: const TextStyle(fontSize: 16),
+                                    textAlign: TextAlign.right,
+                                  )
+                                : Text(
+                                    'No date provided',
+                                    style: TextStyle(color: Colors.grey.shade600, fontSize: 16),
+                                    textAlign: TextAlign.right,
+                                  ),
+                          ),
                         ],
                       ),
-                      const Divider(height: 24),
-                      // Image grid - 3 columns, displays all attached images
-                      GridView.builder(
-                        shrinkWrap: true,
-                        physics: const NeverScrollableScrollPhysics(),
-                        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: 3,
-                          crossAxisSpacing: 8,
-                          mainAxisSpacing: 8,
-                          childAspectRatio: 1,
-                        ),
-                        itemCount: imageUrls.length,
-                        itemBuilder: (context, i) {
-                          final url = imageUrls[i];
-                          final isUrl = url.startsWith('http://') || url.startsWith('https://');
 
-                          // Tappable image thumbnail - opens full size view on tap
-                          return GestureDetector(
-                            onTap: () {
-                              // Show full-size image in dialog
-                              showDialog(
-                                context: context,
-                                builder: (_) => Dialog(
-                                  child: (isUrl || kIsWeb)
-                                      ? Image.network(url, fit: BoxFit.contain)
-                                      : Image.file(File(url), fit: BoxFit.contain),
-                                ),
-                              );
-                            },
-                            child: ClipRRect(
-                              borderRadius: BorderRadius.circular(8),
-                              // Display image based on source type (network URL or local file)
-                              child: (isUrl || kIsWeb)
-                                  ? Image.network(
-                                url,
-                                fit: BoxFit.cover,
-                                errorBuilder: (_, __, ___) => Container(
-                                  color: Colors.grey[300],
-                                  child: const Icon(Icons.broken_image),
-                                ),
-                              )
-                                  : Image.file(
-                                File(url),
-                                fit: BoxFit.cover,
-                                errorBuilder: (_, __, ___) => Container(
-                                  color: Colors.grey[300],
-                                  child: const Icon(Icons.broken_image),
-                                ),
-                              ),
+                      const Divider(height: 32),
+
+                      // Description Section - Icon, label and value
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Icon(Icons.notes, color: Colors.blue.shade700, size: 20),
+                          const SizedBox(width: 8),
+                          const Text(
+                            'Description',
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
                             ),
-                          );
-                        },
+                          ),
+                          const Spacer(),
+                          // Display description or fallback message
+                          Flexible(
+                            child: description.isNotEmpty
+                                ? Text(
+                                    description,
+                                    style: const TextStyle(fontSize: 16),
+                                    textAlign: TextAlign.right,
+                                  )
+                                : Text(
+                                    'No description provided',
+                                    style: TextStyle(color: Colors.grey.shade600, fontSize: 16),
+                                    textAlign: TextAlign.right,
+                                  ),
+                          ),
+                        ],
                       ),
                     ],
                   ),
                 ),
               ),
-          ],
+              const SizedBox(height: 16),
+
+              // Bill & Receipt Images Section - Shows grid of attached images
+              // Only displayed if images are available
+              if (imageUrls.isNotEmpty)
+                Card(
+                  elevation: 2,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Section header
+                        Row(
+                          children: [
+                            Icon(Icons.receipt_long, color: Colors.blue.shade700),
+                            const SizedBox(width: 5),
+                            const Text(
+                              'Bill & Receipt',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const Divider(height: 24),
+                        // Image grid - 3 columns, displays all attached images
+                        GridView.builder(
+                          shrinkWrap: true,
+                          physics: const NeverScrollableScrollPhysics(),
+                          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 3,
+                            crossAxisSpacing: 8,
+                            mainAxisSpacing: 8,
+                            childAspectRatio: 1,
+                          ),
+                          itemCount: imageUrls.length,
+                          itemBuilder: (context, i) {
+                            final url = imageUrls[i];
+                            final isUrl = url.startsWith('http://') || url.startsWith('https://');
+
+                            // Tappable image thumbnail - opens full size view on tap
+                            return GestureDetector(
+                              onTap: () {
+                                // Show full-size image in dialog
+                                showDialog(
+                                  context: context,
+                                  builder: (_) => Dialog(
+                                    child: (isUrl || kIsWeb)
+                                        ? Image.network(url, fit: BoxFit.contain)
+                                        : platformImage(url, isNetwork: false, fit: BoxFit.contain),
+                                  ),
+                                );
+                              },
+                              child: ClipRRect(
+                                borderRadius: BorderRadius.circular(8),
+                                // Display image based on source type (network URL or local file)
+                                child: (isUrl || kIsWeb)
+                                    ? Image.network(
+                                        url,
+                                        fit: BoxFit.cover,
+                                        errorBuilder: (_, __, ___) => Container(
+                                          color: Colors.grey[300],
+                                          child: const Icon(Icons.broken_image),
+                                        ),
+                                      )
+                                    : platformImage(
+                                        url,
+                                        isNetwork: false,
+                                        fit: BoxFit.cover,
+                                        errorBuilder: (_, __, ___) => Container(
+                                          color: Colors.grey[300],
+                                          child: const Icon(Icons.broken_image),
+                                        ),
+                                      ),
+                              ),
+                            );
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/home/home_screen.dart
+++ b/lib/src/features/home/home_screen.dart
@@ -1,36 +1,94 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'bookings/bookings_screen.dart';
 import 'reservations/reservations_screen.dart';
 import 'profile/settings_screen.dart';
 import 'bookings/add_booking_screen.dart';
 import 'dashboard/dashboard_screen.dart';
 import '../todos/todos_screen.dart';
+import '../../core/auth/auth_provider.dart';
+import '../../core/auth/rbac.dart';
+import '../../shared/widgets/access_denied_screen.dart';
 
-class HomeScreen extends StatefulWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  State<HomeScreen> createState() => _HomeScreenState();
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _HomeScreenState extends ConsumerState<HomeScreen> {
   int _selectedIndex = 1;
 
-  final _pages = const [
-    DashboardScreen(),
-    BookingsScreen(),
-    ReservationsScreen(),
-    TodosScreen(), // Full todos screen with both tabs
-    SettingsScreen(),
-  ];
+  List<_HomeTab> _buildTabs(String role, List<String> permissions) {
+    final allTabs = [
+      const _HomeTab(
+        permission: AppPermission.dashboard,
+        label: 'Dashboard',
+        icon: Icons.dashboard,
+        page: DashboardScreen(),
+      ),
+      const _HomeTab(
+        permission: AppPermission.bookings,
+        label: 'Bookings',
+        icon: Icons.book_online,
+        page: BookingsScreen(),
+      ),
+      const _HomeTab(
+        permission: AppPermission.reservations,
+        label: 'Reservations',
+        icon: Icons.calendar_today,
+        page: ReservationsScreen(),
+      ),
+      const _HomeTab(
+        permission: AppPermission.todos,
+        label: 'Todos',
+        icon: Icons.checklist,
+        page: TodosScreen(),
+      ),
+      const _HomeTab(
+        permission: AppPermission.settings,
+        label: 'Settings',
+        icon: Icons.settings,
+        page: SettingsScreen(),
+      ),
+    ];
+
+    return allTabs
+        .where(
+          (tab) => Rbac.canAccess(
+            role: role,
+            permissions: permissions,
+            permission: tab.permission,
+          ),
+        )
+        .toList();
+  }
 
   @override
   Widget build(BuildContext context) {
+    final authState = ref.watch(authProvider);
+    final availableTabs = authState.when(
+      loading: () => <_HomeTab>[],
+      unauthenticated: () => <_HomeTab>[],
+      error: (_) => <_HomeTab>[],
+      authenticated: (_, role, permissions) => _buildTabs(role, permissions),
+    );
+
+    if (availableTabs.isEmpty) {
+      return const AccessDeniedScreen(
+        message: 'No pages are available for your role.',
+        showBackButton: false,
+      );
+    }
+
+    final safeIndex = _selectedIndex.clamp(0, availableTabs.length - 1);
+
     return Scaffold(
-      body: _pages[_selectedIndex],
+      body: availableTabs[safeIndex].page,
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.fixed,
-        currentIndex: _selectedIndex,
+        currentIndex: safeIndex,
         onTap: (index) {
           setState(() {
             _selectedIndex = index;
@@ -39,30 +97,15 @@ class _HomeScreenState extends State<HomeScreen> {
         selectedItemColor: Theme.of(context).primaryColor,
         unselectedItemColor: Colors.grey,
         showUnselectedLabels: true,
-        items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.dashboard),
-            label: "Dashboard",
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.book_online),
-            label: "Bookings",
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.calendar_today),
-            label: "Reservations",
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.checklist),
-            label: "Todos",
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.settings),
-            label: "Settings",
-          ),
+        items: [
+          for (final tab in availableTabs)
+            BottomNavigationBarItem(
+              icon: Icon(tab.icon),
+              label: tab.label,
+            ),
         ],
       ),
-      floatingActionButton: _selectedIndex == 1
+      floatingActionButton: availableTabs[safeIndex].permission == AppPermission.bookings
           ? FloatingActionButton(
         onPressed: () async {
           await Navigator.push(
@@ -75,4 +118,18 @@ class _HomeScreenState extends State<HomeScreen> {
           : null,
     );
   }
+}
+
+class _HomeTab {
+  final AppPermission permission;
+  final String label;
+  final IconData icon;
+  final Widget page;
+
+  const _HomeTab({
+    required this.permission,
+    required this.label,
+    required this.icon,
+    required this.page,
+  });
 }

--- a/lib/src/features/home/home_screen.dart
+++ b/lib/src/features/home/home_screen.dart
@@ -7,8 +7,10 @@ import 'bookings/add_booking_screen.dart';
 import 'dashboard/dashboard_screen.dart';
 import '../todos/todos_screen.dart';
 import '../../core/auth/auth_provider.dart';
+import '../../core/auth/auth_state.dart';
 import '../../core/auth/rbac.dart';
 import '../../shared/widgets/access_denied_screen.dart';
+import 'dart:developer' as developer;
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -54,6 +56,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ),
     ];
 
+    // Filter tabs based on role and permissions
     return allTabs
         .where(
           (tab) => Rbac.canAccess(
@@ -75,7 +78,66 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       authenticated: (_, role, permissions) => _buildTabs(role, permissions),
     );
 
+    // Extract role for debug logging
+    String userRole = 'unknown';
+    if (authState is Authenticated) {
+      final auth = authState;
+      userRole = auth.role;
+    }
+
+    // Debug logging: show role and number of visible tabs
+    developer.log(
+      'HomeScreen build - Role: $userRole, Available tabs: ${availableTabs.length}',
+      name: 'HomeScreen',
+    );
+
     if (availableTabs.isEmpty) {
+      // Check if user is admin - they should always have access to dashboard
+      if (authState is Authenticated) {
+        final auth = authState;
+        if (Rbac.isAdmin(auth.role)) {
+          developer.log(
+            'Admin with no tabs - showing fallback dashboard',
+            name: 'HomeScreen',
+          );
+          // Admin has no tabs available - this is a system issue, not a permission issue.
+          // Show a fallback dashboard or redirect to home.
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text('Dashboard'),
+            ),
+            body: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.dashboard,
+                      size: 64,
+                      color: Colors.blue,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'Welcome',
+                      style: Theme.of(context).textTheme.titleLarge,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'No dashboard features available at the moment.',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        }
+      }
+
+      // Non-admin user has no available pages
       return const AccessDeniedScreen(
         message: 'No pages are available for your role.',
         showBackButton: false,
@@ -83,6 +145,41 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     }
 
     final safeIndex = _selectedIndex.clamp(0, availableTabs.length - 1);
+
+    // BottomNavigationBar requires minimum 2 items (Flutter assertion).
+    // If user has fewer than 2 tabs, render without bottom navigation bar.
+    // This typically occurs for 'staff' and 'user' roles with minimal permissions.
+    final hasMultipleTabs = availableTabs.length >= 2;
+
+    if (!hasMultipleTabs) {
+      developer.log(
+        'Single tab only (${availableTabs.length}) - rendering without BottomNavigationBar. '
+        'This is normal for roles like "staff" and "user" with minimal permissions.',
+        name: 'HomeScreen',
+      );
+
+      // Single-tab fallback: render without bottom navigation
+      return Scaffold(
+        body: availableTabs[safeIndex].page,
+        floatingActionButton: availableTabs[safeIndex].permission == AppPermission.bookings
+            ? FloatingActionButton(
+          onPressed: () async {
+            await Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const AddBookingScreen()),
+            );
+          },
+          child: const Icon(Icons.add),
+        )
+            : null,
+      );
+    }
+
+    // Multi-tab layout: render with BottomNavigationBar
+    developer.log(
+      'Rendering BottomNavigationBar with ${availableTabs.length} tabs',
+      name: 'HomeScreen',
+    );
 
     return Scaffold(
       body: availableTabs[safeIndex].page,

--- a/lib/src/features/home/home_screen.dart
+++ b/lib/src/features/home/home_screen.dart
@@ -85,9 +85,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       userRole = auth.role;
     }
 
-    // Debug logging: show role and number of visible tabs
+    // Debug logging: show role, tab count, and mutation capability
+    // This helps verify staff always has enough tabs for BottomNavigationBar
+    final canMutate = Rbac.canMutate(userRole);
     developer.log(
-      'HomeScreen build - Role: $userRole, Available tabs: ${availableTabs.length}',
+      'HomeScreen.build() - Role: $userRole, Tabs: ${availableTabs.length}, '
+      'CanMutate: $canMutate',
       name: 'HomeScreen',
     );
 

--- a/lib/src/features/home/hotels/add_hotel_screen.dart
+++ b/lib/src/features/home/hotels/add_hotel_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class AddHotelScreen extends ConsumerStatefulWidget {
   const AddHotelScreen({super.key});
@@ -80,14 +82,16 @@ class _AddHotelScreenState extends ConsumerState<AddHotelScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Add Hotel')),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Form(
-          key: _formKey,
-          child: ListView(
-            children: [
+    return RbacGate(
+      permission: AppPermission.partnerHotels,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Add Hotel')),
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Form(
+            key: _formKey,
+            child: ListView(
+              children: [
               _buildTextField("Hotel Name", _nameController),
               _buildTextField("City", _cityController),
               _buildTextField("Phone Number", _phoneController, inputType: TextInputType.phone),
@@ -111,7 +115,8 @@ class _AddHotelScreenState extends ConsumerState<AddHotelScreen> {
                   ),
                 ),
               ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/home/hotels/edit_hotel_screen.dart
+++ b/lib/src/features/home/hotels/edit_hotel_screen.dart
@@ -1,8 +1,10 @@
 // edit_hotel_screen.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
 import '../../../core/auth/hotels_provider.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class EditHotelScreen extends ConsumerStatefulWidget {
   final Map<String, dynamic> hotel;
@@ -80,12 +82,14 @@ class _EditHotelScreenState extends ConsumerState<EditHotelScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Edit Hotel')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: ListView(
-          children: [
+    return RbacGate(
+      permission: AppPermission.partnerHotels,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Edit Hotel')),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: ListView(
+            children: [
             TextField(
               controller: nameController,
               decoration: const InputDecoration(
@@ -125,7 +129,8 @@ class _EditHotelScreenState extends ConsumerState<EditHotelScreen> {
                 ),
               ),
             ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/home/hotels/hotel_details_screen.dart
+++ b/lib/src/features/home/hotels/hotel_details_screen.dart
@@ -4,7 +4,9 @@ import 'package:image_picker/image_picker.dart';
 import 'dart:typed_data';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class HotelDetailsScreen extends ConsumerStatefulWidget {
   final Map<String, dynamic> hotel;
@@ -84,15 +86,17 @@ class _HotelDetailsScreenState extends ConsumerState<HotelDetailsScreen> {
     final hotel = widget.hotel;
     final photos = List<String>.from(hotel['photos'] ?? []);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(hotel['name'] ?? 'Hotel Details'),
-        backgroundColor: Colors.blueAccent,
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: ListView(
-          children: [
+    return RbacGate(
+      permission: AppPermission.partnerHotels,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(hotel['name'] ?? 'Hotel Details'),
+          backgroundColor: Colors.blueAccent,
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: ListView(
+            children: [
             Card(
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
               elevation: 4,
@@ -172,7 +176,8 @@ class _HotelDetailsScreenState extends ConsumerState<HotelDetailsScreen> {
                 }
               },
             ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/home/hotels/hotel_image_page.dart
+++ b/lib/src/features/home/hotels/hotel_image_page.dart
@@ -1,6 +1,8 @@
 import 'package:Zonova_Mist/src/shared/widgets/common_image_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:Zonova_Mist/src/core/auth/rbac.dart';
+import 'package:Zonova_Mist/src/shared/widgets/rbac_gate.dart';
 
 
 
@@ -13,41 +15,44 @@ class HotelDetailsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final photos = List<String>.from(hotel['photos'] ?? []);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Hotel Details - ${hotel['name'] ?? 'Hotel'}'),
-        backgroundColor: Colors.blueAccent,
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: ListView(
-          children: [
-            Card(
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-              elevation: 4,
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(hotel['name'] ?? 'Hotel Name',
-                        style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-                    const SizedBox(height: 8),
-                    Text('City: ${hotel['location']?['city'] ?? '-'}'),
-                    const SizedBox(height: 4),
-                    Text('Star Rating: ${hotel['starRating'] ?? '-'}'),
-                    const SizedBox(height: 4),
-                    Text('Price Range: LKR ${hotel['priceRange'] ?? '-'}'),
-                  ],
+    return RbacGate(
+      permission: AppPermission.partnerHotels,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('Hotel Details - ${hotel['name'] ?? 'Hotel'}'),
+          backgroundColor: Colors.blueAccent,
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: ListView(
+            children: [
+              Card(
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                elevation: 4,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(hotel['name'] ?? 'Hotel Name',
+                          style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                      const SizedBox(height: 8),
+                      Text('City: ${hotel['location']?['city'] ?? '-'}'),
+                      const SizedBox(height: 4),
+                      Text('Star Rating: ${hotel['starRating'] ?? '-'}'),
+                      const SizedBox(height: 4),
+                      Text('Price Range: LKR ${hotel['priceRange'] ?? '-'}'),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(height: 16),
-            CommonImageManager(
-              entityType: 'Hotel', // Capital H
-              entityId: hotel['_id'],
-            ),
-          ],
+              const SizedBox(height: 16),
+              CommonImageManager(
+                entityType: 'Hotel', // Capital H
+                entityId: hotel['_id'],
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/home/hotels/partner_hotels_screen.dart
+++ b/lib/src/features/home/hotels/partner_hotels_screen.dart
@@ -2,12 +2,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/auth/hotels_provider.dart';
 import '../../../core/api/api_service.dart';
 import '../../../shared/widgets/common_image_manager.dart';
 import 'add_hotel_screen.dart';
 import 'edit_hotel_screen.dart';
 import '../../../shared/widgets/app_drawer.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class PartnerHotelsScreen extends ConsumerStatefulWidget {
   const PartnerHotelsScreen({super.key});
@@ -68,7 +70,9 @@ class _PartnerHotelsScreenState extends ConsumerState<PartnerHotelsScreen> {
   Widget build(BuildContext context) {
     final hotelsAsync = ref.watch(hotelsProvider);
 
-    return Scaffold(
+    return RbacGate(
+      permission: AppPermission.partnerHotels,
+      child: Scaffold(
       appBar: AppBar(title: const Text('Partner Hotels'), backgroundColor: Colors.blueAccent),
       drawer: const AppDrawer(),
       body: hotelsAsync.when(
@@ -197,6 +201,7 @@ class _PartnerHotelsScreenState extends ConsumerState<PartnerHotelsScreen> {
             ref.refresh(hotelsProvider);
           }
         },
+      ),
       ),
     );
   }

--- a/lib/src/features/home/profile/settings_screen.dart
+++ b/lib/src/features/home/profile/settings_screen.dart
@@ -3,7 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:Zonova_Mist/src/core/api/api_service.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../shared/widgets/app_drawer.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
@@ -231,23 +233,25 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Settings'),
-        backgroundColor: const Color(0xFFFACC15), // Yellow
-        foregroundColor: const Color(0xFF333333), // Dark Grey
-        elevation: 0,
-      ),
-      drawer: const AppDrawer(),
-      body: _loading
-          ? const Center(child: CircularProgressIndicator())
-          : SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
+    return RbacGate(
+      permission: AppPermission.settings,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Settings'),
+          backgroundColor: const Color(0xFFFACC15), // Yellow
+          foregroundColor: const Color(0xFF333333), // Dark Grey
+          elevation: 0,
+        ),
+        drawer: const AppDrawer(),
+        body: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
               _buildCard(
                 title: 'Guest House Information',
                 children: [
@@ -466,9 +470,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ),
               ),
               const SizedBox(height: 24),
-            ],
-          ),
-        ),
+                    ],
+                  ),
+                ),
+              ),
       ),
     );
   }

--- a/lib/src/features/home/reservations/reservations_screen.dart
+++ b/lib/src/features/home/reservations/reservations_screen.dart
@@ -4,8 +4,10 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:intl/intl.dart';
 import 'reservations_provider.dart';
 import 'package:Zonova_Mist/src/core/api/api_service.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../shared/widgets/app_drawer.dart';
 import '../../../shared/widgets/audio_recordings_widget.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class ReservationsScreen extends ConsumerWidget {
   const ReservationsScreen({super.key});
@@ -166,27 +168,29 @@ class ReservationsScreen extends ConsumerWidget {
     final statusFilter = ref.watch(reservationStatusFilterProvider);
     final searchQuery = ref.watch(reservationSearchProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text("Reservations"),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.search),
-            onPressed: () => _showSearchDialog(context, ref),
-          ),
-          IconButton(
-            icon: Badge(
-              isLabelVisible: currentFilter != 'upcoming' || statusFilter != 'pending' || searchQuery.isNotEmpty,
-              label: const Text('•'),
-              child: const Icon(Icons.filter_list),
+    return RbacGate(
+      permission: AppPermission.reservations,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text("Reservations"),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.search),
+              onPressed: () => _showSearchDialog(context, ref),
             ),
-            onPressed: () => _showFilterSheet(context, ref),
-          ),
-        ],
-      ),
-      drawer: const AppDrawer(),
-      body: Column(
-        children: [
+            IconButton(
+              icon: Badge(
+                isLabelVisible: currentFilter != 'upcoming' || statusFilter != 'pending' || searchQuery.isNotEmpty,
+                label: const Text('•'),
+                child: const Icon(Icons.filter_list),
+              ),
+              onPressed: () => _showFilterSheet(context, ref),
+            ),
+          ],
+        ),
+        drawer: const AppDrawer(),
+        body: Column(
+          children: [
           // Active Filter Chips
           if (currentFilter != 'upcoming' || statusFilter != 'pending' || searchQuery.isNotEmpty)
             Container(
@@ -435,7 +439,8 @@ class ReservationsScreen extends ConsumerWidget {
               ),
             ),
           ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/features/home/rooms/add_room_screen.dart
+++ b/lib/src/features/home/rooms/add_room_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class AddRoomScreen extends ConsumerStatefulWidget {
   const AddRoomScreen({super.key});
@@ -51,14 +53,16 @@ class _AddRoomScreenState extends ConsumerState<AddRoomScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Add Room'), backgroundColor: Colors.blueAccent),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Form(
-          key: _formKey,
-          child: ListView(
-            children: [
+    return RbacGate(
+      permission: AppPermission.rooms,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Add Room'), backgroundColor: Colors.blueAccent),
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Form(
+            key: _formKey,
+            child: ListView(
+              children: [
               TextFormField(
                 controller: _roomNumberController,
                 decoration: const InputDecoration(
@@ -126,7 +130,8 @@ class _AddRoomScreenState extends ConsumerState<AddRoomScreen> {
                   ),
                 ),
               ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/home/rooms/edit_room_screen.dart
+++ b/lib/src/features/home/rooms/edit_room_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
 import '../../../core/auth/rooms_provider.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class EditRoomScreen extends ConsumerStatefulWidget {
   final Map<String, dynamic> room;
@@ -100,12 +102,14 @@ class _EditRoomScreenState extends ConsumerState<EditRoomScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Edit Room')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: ListView(
-          children: [
+    return RbacGate(
+      permission: AppPermission.rooms,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Edit Room')),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: ListView(
+            children: [
             TextField(
               controller: roomNumberController,
               decoration: const InputDecoration(
@@ -166,7 +170,8 @@ class _EditRoomScreenState extends ConsumerState<EditRoomScreen> {
                 child: const Text('Save Changes', style: TextStyle(fontSize: 16)),
               ),
             ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/home/rooms/room_details_screen.dart
+++ b/lib/src/features/home/rooms/room_details_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../shared/widgets/common_image_manager.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 import 'edit_room_screen.dart';
 import 'room_rate_page.dart';
 
@@ -20,32 +22,34 @@ class _RoomDetailsScreenState extends ConsumerState<RoomDetailsScreen> {
 
     print('Room Price Per Night: ${widget.room['pricePerNight']}');
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Room Details'),
-        backgroundColor: Colors.blueAccent,
-        elevation: 2,
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.edit, color: Colors.white),
-            onPressed: () async {
-              final result = await Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => EditRoomScreen(room: widget.room),
-                ),
-              );
-              if (result == true && context.mounted) {
-                setState(() {});
-              }
-            },
-          ),
-        ],
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: ListView(
-          children: [
+    return RbacGate(
+      permission: AppPermission.rooms,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Room Details'),
+          backgroundColor: Colors.blueAccent,
+          elevation: 2,
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.edit, color: Colors.white),
+              onPressed: () async {
+                final result = await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => EditRoomScreen(room: widget.room),
+                  ),
+                );
+                if (result == true && context.mounted) {
+                  setState(() {});
+                }
+              },
+            ),
+          ],
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: ListView(
+            children: [
             Card(
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),
@@ -142,7 +146,8 @@ class _RoomDetailsScreenState extends ConsumerState<RoomDetailsScreen> {
               entityType: 'Room',
               entityId: roomId,
             ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/home/rooms/room_rate_page.dart
+++ b/lib/src/features/home/rooms/room_rate_page.dart
@@ -1,7 +1,9 @@
 import 'package:intl/intl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 
 class RoomRatePage extends ConsumerStatefulWidget {
@@ -288,19 +290,22 @@ class _RoomRatePageState extends ConsumerState<RoomRatePage> {
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text("Room Rate Display"),
-        backgroundColor: Colors.blue,
-        centerTitle: true,
-      ),
-      body: isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : rooms.isEmpty
-          ? const Center(child: Text("No rooms found"))
-          : Padding(
-        padding: const EdgeInsets.all(12.0),
-        child: SingleChildScrollView(child: _buildTable(screenWidth)),
+    return RbacGate(
+      permission: AppPermission.roomRates,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text("Room Rate Display"),
+          backgroundColor: Colors.blue,
+          centerTitle: true,
+        ),
+        body: isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : rooms.isEmpty
+                ? const Center(child: Text("No rooms found"))
+                : Padding(
+                    padding: const EdgeInsets.all(12.0),
+                    child: SingleChildScrollView(child: _buildTable(screenWidth)),
+                  ),
       ),
     );
   }

--- a/lib/src/features/home/rooms/rooms_screen.dart
+++ b/lib/src/features/home/rooms/rooms_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/auth/rooms_provider.dart';
 import '../../../core/api/api_service.dart';
 import '../../../shared/widgets/common_image_manager.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 import 'add_room_screen.dart';
 import 'edit_room_screen.dart';
 import 'room_rate_page.dart';
@@ -75,50 +77,52 @@ class _RoomsScreenState extends ConsumerState<RoomsScreen> {
   Widget build(BuildContext context) {
     final roomsAsync = ref.watch(roomsProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Rooms'),
-        leading: widget.showBackButton
-            ? IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.pop(context),
-        )
-            : null,
-        automaticallyImplyLeading: widget.showBackButton,
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.attach_money),
-            tooltip: 'Room Rates',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const RoomRatePage(),
-                ),
-              );
-            },
-          ),
-        ],
-      ),
-      drawer: widget.showBackButton
-          ? null
-          : Drawer(
-        child: ListView(
-          padding: EdgeInsets.zero,
-          children: [
-            const DrawerHeader(
-              decoration: BoxDecoration(color: Colors.blue),
-              child: Text('Menu', style: TextStyle(color: Colors.white, fontSize: 24)),
-            ),
-            ListTile(
-              leading: const Icon(Icons.home),
-              title: const Text('Home'),
-              onTap: () => Navigator.pop(context),
+    return RbacGate(
+      permission: AppPermission.rooms,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Rooms'),
+          leading: widget.showBackButton
+              ? IconButton(
+                  icon: const Icon(Icons.arrow_back),
+                  onPressed: () => Navigator.pop(context),
+                )
+              : null,
+          automaticallyImplyLeading: widget.showBackButton,
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.attach_money),
+              tooltip: 'Room Rates',
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const RoomRatePage(),
+                  ),
+                );
+              },
             ),
           ],
         ),
-      ),
-      body: roomsAsync.when(
+        drawer: widget.showBackButton
+            ? null
+            : Drawer(
+                child: ListView(
+                  padding: EdgeInsets.zero,
+                  children: [
+                    const DrawerHeader(
+                      decoration: BoxDecoration(color: Colors.blue),
+                      child: Text('Menu', style: TextStyle(color: Colors.white, fontSize: 24)),
+                    ),
+                    ListTile(
+                      leading: const Icon(Icons.home),
+                      title: const Text('Home'),
+                      onTap: () => Navigator.pop(context),
+                    ),
+                  ],
+                ),
+              ),
+        body: roomsAsync.when(
         data: (rooms) {
           if (rooms.isEmpty) {
             return const Center(child: Text('No rooms found.'));
@@ -239,6 +243,7 @@ class _RoomsScreenState extends ConsumerState<RoomsScreen> {
             ref.refresh(roomsProvider);
           }
         },
+        ),
       ),
     );
   }

--- a/lib/src/features/home/staff/add_staff_screen.dart
+++ b/lib/src/features/home/staff/add_staff_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 import 'staff_provider.dart';
 
 class AddStaffScreen extends ConsumerStatefulWidget {
@@ -101,20 +103,22 @@ class _AddStaffScreenState extends ConsumerState<AddStaffScreen> {
   Widget build(BuildContext context) {
     final rolesAsync = ref.watch(staffRolesProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Add Staff Member'),
-        backgroundColor: const Color(0xFFFACC15), // Yellow
-        foregroundColor: const Color(0xFF333333), // Dark Grey
-        elevation: 0,
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
+    return RbacGate(
+      permission: AppPermission.staff,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Add Staff Member'),
+          backgroundColor: const Color(0xFFFACC15), // Yellow
+          foregroundColor: const Color(0xFF333333), // Dark Grey
+          elevation: 0,
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
               // Profile Picture Placeholder
               Center(
                 child: Column(
@@ -305,7 +309,8 @@ class _AddStaffScreenState extends ConsumerState<AddStaffScreen> {
                 )
                     : const Text('Add Staff Member', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
               ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/home/staff/edit_staff_screen.dart
+++ b/lib/src/features/home/staff/edit_staff_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
 import '../../../shared/widgets/common_image_manager.dart';
 import '../../../shared/widgets/profile_picture_uploader.dart';
 import '../../../core/utils/decimal_helper.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 import 'staff_provider.dart';
 
 class EditStaffScreen extends ConsumerStatefulWidget {
@@ -131,17 +133,19 @@ class _EditStaffScreenState extends ConsumerState<EditStaffScreen> {
     final rolesAsync = ref.watch(staffRolesProvider);
     final staffId = widget.staff['_id'] ?? '';
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Edit Staff Member'),
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
+    return RbacGate(
+      permission: AppPermission.staff,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Edit Staff Member'),
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
               // Profile Picture with Uploader
               Center(
                 child: ProfilePictureUploader(
@@ -343,7 +347,8 @@ class _EditStaffScreenState extends ConsumerState<EditStaffScreen> {
                 )
                     : const Text('Update Staff Member'),
               ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/home/staff/staff_screen.dart
+++ b/lib/src/features/home/staff/staff_screen.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../core/api/api_service.dart';
 import '../../../shared/widgets/common_image_manager.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 import 'staff_provider.dart';
 import 'add_staff_screen.dart';
 import 'edit_staff_screen.dart';
@@ -56,7 +58,9 @@ class StaffScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final staffAsync = ref.watch(staffProvider);
 
-    return Scaffold(
+    return RbacGate(
+      permission: AppPermission.staff,
+      child: Scaffold(
       appBar: AppBar(
         title: const Text('Guest Staff'),
         leading: IconButton(
@@ -280,6 +284,7 @@ class StaffScreen extends ConsumerWidget {
         },
         icon: const Icon(Icons.add),
         label: const Text('Add Staff'),
+      ),
       ),
     );
   }

--- a/lib/src/features/home/staff/view_staff_screen.dart
+++ b/lib/src/features/home/staff/view_staff_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import '../../../core/auth/rbac.dart';
 import '../../../shared/widgets/common_image_manager.dart';
 import '../../../core/utils/decimal_helper.dart';
 import 'edit_staff_screen.dart';
+import '../../../shared/widgets/rbac_gate.dart';
 
 class ViewStaffScreen extends ConsumerWidget {
   final Map<String, dynamic> staff;
@@ -64,31 +66,33 @@ class ViewStaffScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final staffId = staff['_id'] ?? '';
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Staff Details'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.edit),
-            onPressed: () async {
-              final result = await Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => EditStaffScreen(staff: staff),
-                ),
-              );
-              if (result == true && context.mounted) {
-                Navigator.pop(context, true);
-              }
-            },
-          ),
-        ],
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
+    return RbacGate(
+      permission: AppPermission.staff,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Staff Details'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.edit),
+              onPressed: () async {
+                final result = await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => EditStaffScreen(staff: staff),
+                  ),
+                );
+                if (result == true && context.mounted) {
+                  Navigator.pop(context, true);
+                }
+              },
+            ),
+          ],
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
             // Profile Section
             Card(
               elevation: 4,
@@ -315,7 +319,8 @@ class ViewStaffScreen extends ConsumerWidget {
           ],
         ),
       ),
-    );
+    ),
+  );
   }
 
   Widget _buildInfoRow(IconData icon, String label, String value) {

--- a/lib/src/features/todos/add_todo_screen.dart
+++ b/lib/src/features/todos/add_todo_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import '../../core/auth/rbac.dart';
+import '../../shared/widgets/rbac_gate.dart';
 import 'models/todo_model.dart';
 import 'providers/todo_provider.dart';
 
@@ -47,20 +49,22 @@ class _AddTodoScreenState extends ConsumerState<AddTodoScreen> {
   Widget build(BuildContext context) {
     final usersAsync = ref.watch(usersProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.todo == null ? 'Add Task' : 'Edit Task'),
-        elevation: 0,
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Title field (required)
-              TextFormField(
+    return RbacGate(
+      permission: AppPermission.todos,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(widget.todo == null ? 'Add Task' : 'Edit Task'),
+          elevation: 0,
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Title field (required)
+                TextFormField(
                 controller: _titleController,
                 decoration: InputDecoration(
                   labelText: 'Title *',
@@ -295,7 +299,8 @@ class _AddTodoScreenState extends ConsumerState<AddTodoScreen> {
                   ),
                 ),
               ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/todos/todos_screen.dart
+++ b/lib/src/features/todos/todos_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/auth/rbac.dart';
 import '../../shared/widgets/app_drawer.dart';
+import '../../shared/widgets/rbac_gate.dart';
 import 'providers/todo_provider.dart';
 import 'tasks_view.dart';
 import 'my_todos_view.dart';
@@ -36,69 +38,72 @@ class _TodosScreenState extends ConsumerState<TodosScreen> with SingleTickerProv
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: const Color(0xFFFACC15), // Yellow
-        foregroundColor: const Color(0xFF333333), // Dark Grey
-        title: const Text('Todos'),
-        elevation: 0,
-        bottom: TabBar(
-          controller: _tabController,
-          indicatorColor: const Color(0xFF333333), // Dark Grey
-          labelColor: const Color(0xFF333333),
-          unselectedLabelColor: Colors.black54,
-          tabs: const [
-            Tab(
-              icon: Icon(Icons.list_alt),
-              text: 'Tasks',
-            ),
-            Tab(
-              icon: Icon(Icons.assignment_ind),
-              text: 'My Todos',
+    return RbacGate(
+      permission: AppPermission.todos,
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: const Color(0xFFFACC15), // Yellow
+          foregroundColor: const Color(0xFF333333), // Dark Grey
+          title: const Text('Todos'),
+          elevation: 0,
+          bottom: TabBar(
+            controller: _tabController,
+            indicatorColor: const Color(0xFF333333), // Dark Grey
+            labelColor: const Color(0xFF333333),
+            unselectedLabelColor: Colors.black54,
+            tabs: const [
+              Tab(
+                icon: Icon(Icons.list_alt),
+                text: 'Tasks',
+              ),
+              Tab(
+                icon: Icon(Icons.assignment_ind),
+                text: 'My Todos',
+              ),
+            ],
+          ),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              onPressed: () {
+                if (_tabController.index == 0) {
+                  ref.read(todoProvider.notifier).fetchTodos();
+                } else {
+                  ref.read(myTodoProvider.notifier).fetchMyTodos();
+                }
+              },
             ),
           ],
         ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: () {
-              if (_tabController.index == 0) {
-                ref.read(todoProvider.notifier).fetchTodos();
-              } else {
-                ref.read(myTodoProvider.notifier).fetchMyTodos();
-              }
-            },
-          ),
-        ],
-      ),
-      drawer: const AppDrawer(),
-      body: TabBarView(
-        controller: _tabController,
-        children: const [
-          TasksView(),
-          MyTodosView(),
-        ],
-      ),
-      floatingActionButton: _tabController.index == 0
-          ? FloatingActionButton(
-        backgroundColor: const Color(0xFFFACC15),
-        foregroundColor: Colors.white,
-        onPressed: () async {
-          final result = await Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const AddTodoScreen(),
-            ),
-          );
+        drawer: const AppDrawer(),
+        body: TabBarView(
+          controller: _tabController,
+          children: const [
+            TasksView(),
+            MyTodosView(),
+          ],
+        ),
+        floatingActionButton: _tabController.index == 0
+            ? FloatingActionButton(
+                backgroundColor: const Color(0xFFFACC15),
+                foregroundColor: Colors.white,
+                onPressed: () async {
+                  final result = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const AddTodoScreen(),
+                    ),
+                  );
 
-          // Refresh if task was created
-          if (result == true) {
-            ref.read(todoProvider.notifier).fetchTodos();
-          }
-        },
-        child: const Icon(Icons.add),
-      )
-          : null,
+                  // Refresh if task was created
+                  if (result == true) {
+                    ref.read(todoProvider.notifier).fetchTodos();
+                  }
+                },
+                child: const Icon(Icons.add),
+              )
+            : null,
+      ),
     );
   }
 }

--- a/lib/src/shared/widgets/access_denied_screen.dart
+++ b/lib/src/shared/widgets/access_denied_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+class AccessDeniedScreen extends StatelessWidget {
+  final String message;
+  final String? permissionLabel;
+  final bool showBackButton;
+
+  const AccessDeniedScreen({
+    super.key,
+    required this.message,
+    this.permissionLabel,
+    this.showBackButton = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: showBackButton
+          ? AppBar(
+              title: const Text('Access Denied'),
+            )
+          : null,
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.lock_outline, size: 64, color: Colors.redAccent),
+              const SizedBox(height: 16),
+              Text(
+                message,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              if (permissionLabel != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  'Required permission: $permissionLabel',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ],
+              if (showBackButton) ...[
+                const SizedBox(height: 24),
+                ElevatedButton.icon(
+                  onPressed: () {
+                    Navigator.of(context).maybePop();
+                  },
+                  icon: const Icon(Icons.arrow_back),
+                  label: const Text('Go Back'),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/shared/widgets/app_drawer.dart
+++ b/lib/src/shared/widgets/app_drawer.dart
@@ -8,6 +8,7 @@ import '../../features/home/expenses/expenses_list_page.dart';
 import './logout_button.dart';
 import '../../features/home/assets/asset_screen.dart';
 import '../../core/auth/auth_provider.dart';
+import '../../core/auth/auth_state.dart';
 import '../../core/auth/rbac.dart';
 
 class AppDrawer extends ConsumerWidget {
@@ -18,16 +19,19 @@ class AppDrawer extends ConsumerWidget {
     final authState = ref.watch(authProvider);
 
     bool hasAccess(AppPermission permission) {
-      return authState.when(
-        loading: () => false,
-        unauthenticated: () => false,
-        error: (_) => false,
-        authenticated: (_, role, permissions) => Rbac.canAccess(
-          role: role,
-          permissions: permissions,
+      // Use runtime type checks because AuthState doesn't provide `when` globally
+      if (authState is AuthLoading) return false;
+      if (authState is Unauthenticated) return false;
+      if (authState is AuthError) return false;
+      if (authState is Authenticated) {
+        final auth = authState as Authenticated;
+        return Rbac.canAccess(
+          role: auth.role,
+          permissions: auth.permissions,
           permission: permission,
-        ),
-      );
+        );
+      }
+      return false;
     }
 
     return Drawer(

--- a/lib/src/shared/widgets/app_drawer.dart
+++ b/lib/src/shared/widgets/app_drawer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../features/home/staff/staff_screen.dart';
 import '../../features/home/rooms/rooms_screen.dart';
 import '../../features/home/rooms/room_rate_page.dart';
@@ -6,12 +7,29 @@ import '../../features/home/hotels/partner_hotels_screen.dart';
 import '../../features/home/expenses/expenses_list_page.dart';
 import './logout_button.dart';
 import '../../features/home/assets/asset_screen.dart';
+import '../../core/auth/auth_provider.dart';
+import '../../core/auth/rbac.dart';
 
-class AppDrawer extends StatelessWidget {
+class AppDrawer extends ConsumerWidget {
   const AppDrawer({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authProvider);
+
+    bool hasAccess(AppPermission permission) {
+      return authState.when(
+        loading: () => false,
+        unauthenticated: () => false,
+        error: (_) => false,
+        authenticated: (_, role, permissions) => Rbac.canAccess(
+          role: role,
+          permissions: permissions,
+          permission: permission,
+        ),
+      );
+    }
+
     return Drawer(
       child: Container(
         color: Colors.white,
@@ -96,140 +114,152 @@ class AppDrawer extends StatelessWidget {
                   ),
 
                   // Rooms Menu Item
-                  ListTile(
-                    leading: Icon(Icons.meeting_room, color: Colors.blue.shade700),
-                    title: const Text(
-                      'Rooms',
-                      style: TextStyle(fontWeight: FontWeight.w500),
+                  if (hasAccess(AppPermission.rooms)) ...[
+                    ListTile(
+                      leading: Icon(Icons.meeting_room, color: Colors.blue.shade700),
+                      title: const Text(
+                        'Rooms',
+                        style: TextStyle(fontWeight: FontWeight.w500),
+                      ),
+                      subtitle: const Text(
+                        'Manage rooms',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const RoomsScreen(showBackButton: true),
+                          ),
+                        );
+                      },
                     ),
-                    subtitle: const Text(
-                      'Manage rooms',
-                      style: TextStyle(fontSize: 12),
-                    ),
-                    onTap: () {
-                      Navigator.pop(context);
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const RoomsScreen(showBackButton: true),
-                        ),
-                      );
-                    },
-                  ),
-                  const Divider(height: 1),
+                    const Divider(height: 1),
+                  ],
 
-                  ListTile(
-                    leading: Icon(Icons.attach_money, color: Colors.blue.shade700),
-                    title: const Text(
-                      'Room Rates',
-                      style: TextStyle(fontWeight: FontWeight.w500),
+                  if (hasAccess(AppPermission.roomRates)) ...[
+                    ListTile(
+                      leading: Icon(Icons.attach_money, color: Colors.blue.shade700),
+                      title: const Text(
+                        'Room Rates',
+                        style: TextStyle(fontWeight: FontWeight.w500),
+                      ),
+                      subtitle: const Text(
+                        'Manage room rates',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const RoomRatePage(),
+                          ),
+                        );
+                      },
                     ),
-                    subtitle: const Text(
-                      'Manage room rates',
-                      style: TextStyle(fontSize: 12),
-                    ),
-                    onTap: () {
-                      Navigator.pop(context);
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const RoomRatePage(),
-                        ),
-                      );
-                    },
-                  ),
-                  const Divider(height: 1),
+                    const Divider(height: 1),
+                  ],
 
                   // Expenses Menu Item
-                  ListTile(
-                    leading: Icon(Icons.receipt_long, color: Colors.blue.shade700),
-                    title: const Text(
-                      'Expenses',
-                      style: TextStyle(fontWeight: FontWeight.w500),
+                  if (hasAccess(AppPermission.expenses)) ...[
+                    ListTile(
+                      leading: Icon(Icons.receipt_long, color: Colors.blue.shade700),
+                      title: const Text(
+                        'Expenses',
+                        style: TextStyle(fontWeight: FontWeight.w500),
+                      ),
+                      subtitle: const Text(
+                        'View expenses',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const ExpensesListPage(),
+                          ),
+                        );
+                      },
                     ),
-                    subtitle: const Text(
-                      'View expenses',
-                      style: TextStyle(fontSize: 12),
-                    ),
-                    onTap: () {
-                      Navigator.pop(context);
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const ExpensesListPage(),
-                        ),
-                      );
-                    },
-                  ),
-                  const Divider(height: 1),
+                    const Divider(height: 1),
+                  ],
 
-                  ListTile(
-                    leading: Icon(Icons.hotel, color: Colors.blue.shade700),
-                    title: const Text(
-                      'Partner Hotels',
-                      style: TextStyle(fontWeight: FontWeight.w500),
+                  if (hasAccess(AppPermission.partnerHotels)) ...[
+                    ListTile(
+                      leading: Icon(Icons.hotel, color: Colors.blue.shade700),
+                      title: const Text(
+                        'Partner Hotels',
+                        style: TextStyle(fontWeight: FontWeight.w500),
+                      ),
+                      subtitle: const Text(
+                        'Manage partner hotels',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const PartnerHotelsScreen(),
+                          ),
+                        );
+                      },
                     ),
-                    subtitle: const Text(
-                      'Manage partner hotels',
-                      style: TextStyle(fontSize: 12),
-                    ),
-                    onTap: () {
-                      Navigator.pop(context);
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const PartnerHotelsScreen(),
-                        ),
-                      );
-                    },
-                  ),
-                  const Divider(height: 1),
+                    const Divider(height: 1),
+                  ],
 
                   // Staff Menu Item
-                  ListTile(
-                    leading: Icon(Icons.people, color: Colors.blue.shade700),
-                    title: const Text(
-                      'Guest Staff',
-                      style: TextStyle(fontWeight: FontWeight.w500),
+                  if (hasAccess(AppPermission.staff)) ...[
+                    ListTile(
+                      leading: Icon(Icons.people, color: Colors.blue.shade700),
+                      title: const Text(
+                        'Guest Staff',
+                        style: TextStyle(fontWeight: FontWeight.w500),
+                      ),
+                      subtitle: const Text(
+                        'Manage staff members',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const StaffScreen(),
+                          ),
+                        );
+                      },
                     ),
-                    subtitle: const Text(
-                      'Manage staff members',
-                      style: TextStyle(fontSize: 12),
-                    ),
-                    onTap: () {
-                      Navigator.pop(context);
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const StaffScreen(),
-                        ),
-                      );
-                    },
-                  ),
-                  const Divider(height: 1),
+                    const Divider(height: 1),
+                  ],
 
                   // Assets Menu Item
-                  ListTile(
-                    leading: Icon(Icons.business_center, color: Colors.blue.shade700),
-                    title: const Text(
-                      'Assets',
-                      style: TextStyle(fontWeight: FontWeight.w500),
+                  if (hasAccess(AppPermission.assets)) ...[
+                    ListTile(
+                      leading: Icon(Icons.business_center, color: Colors.blue.shade700),
+                      title: const Text(
+                        'Assets',
+                        style: TextStyle(fontWeight: FontWeight.w500),
+                      ),
+                      subtitle: const Text(
+                        'Manage assets',
+                        style: TextStyle(fontSize: 12),
+                      ),
+                      onTap: () {
+                        Navigator.pop(context);
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const AssetsScreen(),
+                          ),
+                        );
+                      },
                     ),
-                    subtitle: const Text(
-                      'Manage assets',
-                      style: TextStyle(fontSize: 12),
-                    ),
-                    onTap: () {
-                      Navigator.pop(context);
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const AssetsScreen(),
-                        ),
-                      );
-                    },
-                  ),
-                  const Divider(height: 1),
+                    const Divider(height: 1),
+                  ],
 
                   // About Menu Item
                   ListTile(

--- a/lib/src/shared/widgets/platform_image_stub.dart
+++ b/lib/src/shared/widgets/platform_image_stub.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/widgets.dart';
+
+// Stub implementation used on platforms without dart:io (e.g., web).
+// Falls back to Image.network for any path since local files aren't available on web.
+Widget platformImage(
+  String path, {
+  bool isNetwork = false,
+  BoxFit fit = BoxFit.cover,
+  ImageErrorWidgetBuilder? errorBuilder,
+}) {
+  if (isNetwork) {
+    return Image.network(
+      path,
+      fit: fit,
+      errorBuilder: errorBuilder,
+    );
+  }
+
+  // Local file paths are not supported on web - try network as a best-effort fallback
+  return Image.network(
+    path,
+    fit: fit,
+    errorBuilder: errorBuilder,
+  );
+}

--- a/lib/src/shared/widgets/rbac_gate.dart
+++ b/lib/src/shared/widgets/rbac_gate.dart
@@ -35,19 +35,90 @@ class RbacGate extends ConsumerWidget {
         permissionLabel: permissionLabel,
       ),
       authenticated: (userName, role, permissions) {
+        // Check if user can access this permission
         final allowed = Rbac.canAccess(
           role: role,
           permissions: permissions,
           permission: permission,
         );
+
         if (allowed) {
+          // User has access - show the page
           return child;
         }
+
+        // Access denied. Show different messages based on role type.
+        if (Rbac.isAdmin(role)) {
+          // Admin should never be denied, but if it happens, redirect to home
+          // This indicates a system issue, not a permission issue.
+          return _AdminAccessFallback(
+            permissionLabel: permissionLabel,
+            userName: userName,
+          );
+        }
+
+        // Non-admin user denied access - show standard access denied
         return AccessDeniedScreen(
           message: 'You do not have access to this page.',
           permissionLabel: permissionLabel,
         );
       },
+    );
+  }
+}
+
+/// Fallback widget when admin unexpectedly can't access a feature.
+/// This should rarely happen (indicates a system issue, not permission issue).
+class _AdminAccessFallback extends StatelessWidget {
+  final String permissionLabel;
+  final String userName;
+
+  const _AdminAccessFallback({
+    required this.permissionLabel,
+    required this.userName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Feature Unavailable'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.warning_outlined,
+                size: 64,
+                color: Colors.orange,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Feature Not Available',
+                style: Theme.of(context).textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'The "$permissionLabel" feature is not available right now.',
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton.icon(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+                icon: const Icon(Icons.home),
+                label: const Text('Go Home'),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/shared/widgets/rbac_gate.dart
+++ b/lib/src/shared/widgets/rbac_gate.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/auth/auth_provider.dart';
+import '../../core/auth/auth_state.dart';
+import '../../core/auth/rbac.dart';
+import 'access_denied_screen.dart';
+
+class RbacGate extends ConsumerWidget {
+  final AppPermission permission;
+  final Widget child;
+
+  const RbacGate({
+    super.key,
+    required this.permission,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authProvider);
+    final permissionLabel = permissionLabels[permission] ?? permission.name;
+
+    return authState.when(
+      loading: () => const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      unauthenticated: () => AccessDeniedScreen(
+        message: 'Please sign in to access this page.',
+        permissionLabel: permissionLabel,
+        showBackButton: false,
+      ),
+      error: (message) => AccessDeniedScreen(
+        message: message,
+        permissionLabel: permissionLabel,
+      ),
+      authenticated: (userName, role, permissions) {
+        final allowed = Rbac.canAccess(
+          role: role,
+          permissions: permissions,
+          permission: permission,
+        );
+        if (allowed) {
+          return child;
+        }
+        return AccessDeniedScreen(
+          message: 'You do not have access to this page.',
+          permissionLabel: permissionLabel,
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Introduce role-based access control so pages and navigation only show/allow actions the signed-in user is permitted to access, driven by role/permission data returned from the API (backend branch: `ZonovaMistAPI` `codex/add-role-based-authentication`).
- Provide a clear UX for denied access and a reusable gate to centralize permission checks across the app.

### Description
- Added RBAC core: `lib/src/core/auth/rbac.dart` defines `AppPermission`, permission keys/labels, role -> permission defaults, and `Rbac.canAccess` to evaluate access by role or explicit permission list.
- Extended auth state/provider to carry role and permissions: `AuthState` now contains `role` and `permissions`, and `auth_provider.dart` persists/loads them (`user_role`, `user_permissions`) and extracts permissions from login response.
- UI components: added `RbacGate` (`lib/src/shared/widgets/rbac_gate.dart`) to wrap screens and `AccessDeniedScreen` to show a consistent denial UI (`lib/src/shared/widgets/access_denied_screen.dart`).
- Applied gating and visibility changes across the app: home tabs and bottom nav are filtered by permission (`home_screen.dart`), drawer items are shown conditionally (`app_drawer.dart`), and many feature screens/forms/pages were wrapped with `RbacGate` (examples: bookings, reservations, todos, settings, rooms, assets, expenses, staff, hotels, and related add/edit/detail screens).

### Testing
- Attempted to run formatter across changed Dart files with `dart format $(git diff --name-only --diff-filter=ACM | rg '\.dart$')`, but the command failed because `dart` is not available in this environment. (Formatting/linting not executed.)
- No automated unit or integration tests were executed in this environment; changes are limited to adding RBAC checks and wiring auth state and should be validated by running the app and running existing test/CI in a Dart/Flutter environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ed9e1ecc8330a9274dc82213b6a8)